### PR TITLE
[DOCKER] Fixing docker-compose, and not running Runtime by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
             context: .
             dockerfile: docker/Dockerfile
         image: pierobotics/runtime:latest
-        command: bash -c "./runtime build && ./runtime run"
+        command: bash -c "./runtime build && tail -f /dev/null"
         volumes:
             # Changes in local runtime/ and container /root/runtime are synced
             - .:/root/runtime

--- a/docker/README.md
+++ b/docker/README.md
@@ -22,17 +22,17 @@ If you are on Windows/Mac, you will be using Docker Desktop which will already h
 
 If you are just starting out and want to get into development quickly, go to the `runtime` folder and do
 
-    docker-compose run --rm runtime bash
+    docker-compose up -d
 
-which will begin a bash shell in the Docker container. From there you can call `runtime run` and the other `runtime` commands mentioned in the root README. Also, in another terminal you can do
+which will start the Docker container. Now you can do
 
     docker-compose exec runtime bash
 
-to run/test other things within the container. By default, the `runtime/` git folder and `/root/runtime` will be linked so changes in one place will also change in the other place.
+to open up a bash terminal in the container. You can repeat this command to get however many bash terminals you want. From the container, you can then call `runtime run` and the other `runtime` commands mentioned in the root README. Additionally, the `runtime/` git folder and `/root/runtime` will be linked so changes in the container will also change on your machine.
 
 ## Stopping
 
-To stop the container, just exit all your shells or do 
+To stop the container, do 
 
     docker-compose down
 

--- a/logger/logger.config
+++ b/logger/logger.config
@@ -7,7 +7,7 @@
 // Do not leave any setting blank.
 
 // Output logs to terminal (stdout)? (Yes/No)
-LOG_TO_STDOUT: NO
+LOG_TO_STDOUT: YES
 
 // Output logs to log file? (Yes/No)
 LOG_TO_FILE: YES

--- a/tests/cli/net_handler_cli.c
+++ b/tests/cli/net_handler_cli.c
@@ -236,7 +236,7 @@ void prompt_device_data() {
     int num_devices = 0;
     uint8_t dev_type;
     long long int temp;
-    dev_data_t data[MAX_DEVICES];
+    dev_subs_t data[MAX_DEVICES];
     device_t* curr_dev;
 
     // first get the list of device names
@@ -330,7 +330,7 @@ void prompt_device_data() {
 
     // send
     printf("Sending Device Data message!\n\n");
-    send_device_data(data, num_devices);
+    send_device_subs(data, num_devices);
 
     // free everything
     for (int i = 0; i < num_devices; i++) {


### PR DESCRIPTION
Fixing the docker-compose command, and making it so that by default, the container doesn't run Runtime. The developer now must run the `runtime` commands manually when they wish.