### PR TITLE
[TEST] Added support for rerouting output in net_handler_cli

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -34,7 +34,7 @@ RUN curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/inst
     arduino-cli core update-index
 
 # Install debug packages
-RUN apt-get -y install procps htop tmux nano net-tools
+RUN apt-get -y install procps htop tmux nano net-tools clang-format
 
 WORKDIR /root
 

--- a/tests/cli/net_handler_cli.c
+++ b/tests/cli/net_handler_cli.c
@@ -2,6 +2,7 @@
 
 #define MAX_CMD_LEN 64  // maximum length of user input
 
+
 // ********************************** COMMAND-SPECIFIC FUNCTIONS  ****************************** //
 
 void prompt_run_mode() {
@@ -338,6 +339,21 @@ void prompt_device_data() {
     }
 }
 
+void prompt_reroute_output() {
+    char *dest = "net_handler_output.log";
+    char nextcmd[MAX_CMD_LEN];
+
+    printf("Enter new output destination (blank for net_handler_output.log): ");
+    fgets(nextcmd, MAX_CMD_LEN, stdin);
+    if (strcmp(nextcmd, "\n") != 0) {
+        // truncate new line character
+        nextcmd[strcspn(nextcmd, "\n")] = 0;
+        dest = nextcmd;
+    }
+
+    update_tcp_output_fp(dest);
+}
+
 void display_help() {
     printf("This is the main menu. Type one of the following commands to send a message to net_handler.\n");
     printf("Once you type one of the commands and hit \"enter\", follow on-screen instructions.\n");
@@ -349,6 +365,7 @@ void display_help() {
     printf("\tchallenge data     send a Challenge Data message\n");
     printf("\tdevice data        send a Device Data message (send a subscription request)\n");
     printf("\tview device data   view the next UDP packet sent to Dawn containing most recent device data\n");
+    printf("\treroute output     reroute output to a file\n");
     printf("\thelp               display this help text\n");
     printf("\texit               exit the Net Handler CLI\n");
 }
@@ -381,6 +398,8 @@ int main() {
         // compare input string against the available commands
         if (strcmp(nextcmd, "exit\n") == 0) {
             stop = 1;
+        } else if (strcmp(nextcmd, "reroute output\n") == 0) {
+            prompt_reroute_output();
         } else if (strcmp(nextcmd, "run mode\n") == 0) {
             prompt_run_mode();
         } else if (strcmp(nextcmd, "start pos\n") == 0) {

--- a/tests/cli/net_handler_cli.c
+++ b/tests/cli/net_handler_cli.c
@@ -340,7 +340,7 @@ void prompt_device_data() {
 }
 
 void prompt_reroute_output() {
-    char *dest = "net_handler_output.log";
+    char* dest = "net_handler_output.log";
     char nextcmd[MAX_CMD_LEN];
 
     printf("Enter new output destination (blank for net_handler_output.log): ");

--- a/tests/client/net_handler_client.c
+++ b/tests/client/net_handler_client.c
@@ -10,6 +10,7 @@ int print_next_udp;                     // 0 if we want to suppress incoming dev
 int nh_tcp_shep_fd = -1;     // holds file descriptor for TCP Shepherd socket
 int nh_tcp_dawn_fd = -1;     // holds file descriptor for TCP Dawn socket
 int nh_udp_fd = -1;          // holds file descriptor for UDP Dawn socket
+FILE* default_tcp_fp = NULL; // holds default output location of incoming TCP messages (stdout if NULL)
 FILE* tcp_output_fp = NULL;  // holds current output location of incoming TCP messages
 FILE* udp_output_fp = NULL;  // holds current output location of incoming UDP messages
 FILE* null_fp = NULL;        // file pointer to /dev/null
@@ -224,7 +225,11 @@ static void* output_dump(void* args) {
             curr_time = millis();
             if (curr_time - last_received_time >= enable_threshold) {
                 less_than_disable_thresh = 0;
-                tcp_output_fp = stdout;
+                if (default_tcp_fp == NULL) {
+                    tcp_output_fp = stdout;
+                } else {
+                    tcp_output_fp = default_tcp_fp;
+                }
             }
             if (curr_time - last_received_time <= disable_threshold) {
                 less_than_disable_thresh++;
@@ -512,4 +517,8 @@ void print_next_dev_data() {
     udp_output_fp = stdout;
     pthread_mutex_unlock(&print_udp_mutex);
     usleep(400000);  // allow time for output_dump to react and generate output before returning to client
+}
+
+void update_tcp_output_fp(char* output_address) {
+    default_tcp_fp = fopen(output_address, "w");
 }

--- a/tests/client/net_handler_client.c
+++ b/tests/client/net_handler_client.c
@@ -7,13 +7,13 @@ pthread_t dump_tid;                     // holds the thread id of the output dum
 pthread_mutex_t print_udp_mutex;        // lock over whether to print the next received udp
 int print_next_udp;                     // 0 if we want to suppress incoming dev data, 1 to print incoming dev data to stdout
 
-int nh_tcp_shep_fd = -1;     // holds file descriptor for TCP Shepherd socket
-int nh_tcp_dawn_fd = -1;     // holds file descriptor for TCP Dawn socket
-int nh_udp_fd = -1;          // holds file descriptor for UDP Dawn socket
-FILE* default_tcp_fp = NULL; // holds default output location of incoming TCP messages (stdout if NULL)
-FILE* tcp_output_fp = NULL;  // holds current output location of incoming TCP messages
-FILE* udp_output_fp = NULL;  // holds current output location of incoming UDP messages
-FILE* null_fp = NULL;        // file pointer to /dev/null
+int nh_tcp_shep_fd = -1;      // holds file descriptor for TCP Shepherd socket
+int nh_tcp_dawn_fd = -1;      // holds file descriptor for TCP Dawn socket
+int nh_udp_fd = -1;           // holds file descriptor for UDP Dawn socket
+FILE* default_tcp_fp = NULL;  // holds default output location of incoming TCP messages (stdout if NULL)
+FILE* tcp_output_fp = NULL;   // holds current output location of incoming TCP messages
+FILE* udp_output_fp = NULL;   // holds current output location of incoming UDP messages
+FILE* null_fp = NULL;         // file pointer to /dev/null
 
 // ************************************* HELPER FUNCTIONS ************************************** //
 

--- a/tests/client/net_handler_client.h
+++ b/tests/client/net_handler_client.h
@@ -81,4 +81,11 @@ void send_device_subs(dev_subs_t* subs, int num_devices);
  */
 void print_next_dev_data();
 
+/**
+ * Updates the file pointer receiving TCP messages coming into Dawn or Shepherd.
+ * Arguments:
+ *    - output_address: address of the file stream for new output destination
+ */
+void update_tcp_output_fp(char* output_address);
+
 #endif


### PR DESCRIPTION
Added `reroute output` command to `net_handler_cli` to redirect some outputs in the net handler CLI to a separate file to avoid overcrowding the net handler terminal window. 

Closes issue #79 

