### PR TITLE
[DEV_HANDLER] Fixes runtime crash when running as systemd

### DIFF
--- a/dev_handler/dev_handler.c
+++ b/dev_handler/dev_handler.c
@@ -708,7 +708,8 @@ int connect_socket(const char* socket_name) {
  */
 int serialport_open(const char* port_name) {
     // Open the serialport for reading and writing
-    int fd = open(port_name, O_RDWR);
+    // Need to specify O_NOCTTY to prevent attaching devices from becoming controlling terminals; see wiki
+    int fd = open(port_name, O_RDWR | O_NOCTTY);
     if (fd == -1) {
         log_printf(ERROR, "serialport_open: Unable to open port %s", port_name);
         return -1;


### PR DESCRIPTION
See linked issue for explanation of bug. This change fixes said bug!

- Added flag `O_NOCTTY` to line 711 of `dev_handler.c`
- Change prevents connecting devices from becoming controlling terminals

Closes #145 