### PR TITLE
[SYSTEMD] Implementing circular restarting of Runtime

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,5 +1,8 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
+# This script runs all of Runtime in a terminal
+
+# function to clean up shared memory
 function cleanup() {
     sleep 0.5
     cd shm_wrapper && ./shm_stop
@@ -7,13 +10,15 @@ function cleanup() {
 }
 
 cd shm_wrapper && ./shm_start &
-trap cleanup INT
+trap cleanup INT # sets cleanup as Ctrl-C handler
 sleep 0.5
-#cd shm_wrapper && ./static_dev &
-#sleep 0.5
+
+# starts all three Runtime processes in the background
 cd net_handler && ./net_handler &
 sleep 0.5
 cd executor && ./executor &
 sleep 0.5
 cd dev_handler && ./dev_handler &
+
+# waits for background processes to stop (they won't ever stop)
 wait

--- a/systemd/dev_handler.service
+++ b/systemd/dev_handler.service
@@ -2,10 +2,11 @@
 Description=Device handler process for Runtime
 BindsTo=executor.service net_handler.service
 After=shm_start.service
+Conflicts=shm_stop.service
 OnFailure=shm_stop.service
 
 [Service]
-Type=oneshot
+Type=simple
 User=pi
 WorkingDirectory=/home/pi/runtime/dev_handler
 ExecStart=/home/pi/runtime/dev_handler/dev_handler

--- a/systemd/executor.service
+++ b/systemd/executor.service
@@ -2,10 +2,11 @@
 Description=Executor process for Runtime
 BindsTo=dev_handler.service net_handler.service
 After=shm_start.service
+Conflicts=shm_stop.service
 OnFailure=shm_stop.service
 
 [Service]
-Type=oneshot
+Type=simple
 User=pi
 WorkingDirectory=/home/pi/runtime/executor
 ExecStart=/home/pi/runtime/executor/executor

--- a/systemd/net_handler.service
+++ b/systemd/net_handler.service
@@ -2,10 +2,11 @@
 Description=Net handler process for Runtime
 BindsTo=dev_handler.service executor.service
 After=shm_start.service
+Conflicts=shm_stop.service
 OnFailure=shm_stop.service
 
 [Service]
-Type=oneshot
+Type=simple
 User=pi
 WorkingDirectory=/home/pi/runtime/net_handler
 ExecStart=/home/pi/runtime/net_handler/net_handler

--- a/systemd/shm_stop.service
+++ b/systemd/shm_stop.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Shared memory cleanup process for Runtime
 After=dev_handler.service executor.service net_handler.service
-OnFailure=dev_handler.service executor.service net_handler.service shm_stop.service
+OnFailure=dev_handler.service executor.service net_handler.service shm_start.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Much simpler change than anticipated! I think it was a combination of a typo in `shm_stop.service` and me adding more `Before` and `After` dependencies to the services.

- Changed type of net_handler, dev_handler, and executor services to "`simple`"
- Listed `shm_start.service` as an `OnFailure` dependency of `shm_stop` (I think this was a typo before)
- Was working on a different solution before and added some comments to `run.sh`

I tested this and it does seem to work, if you try killing one of the processes using `kill -6`, it instantaneously regenerates a new instance of Runtime. The change from `oneshot` to `simple` is more of an aesthetic thing; when the processes are running now and you do `systemctl status executor`, for example, it will display `active (running)` as its status in bold green, which is pretty satisfying :P 

If you want to stop Runtime completely, doing `sudo systemctl stop dev_handler` (or `executor` or `net_handler`) followed by `rm /dev/shm/*` works (stopping those services doesn't automatically trigger `shm_stop.service`--you have to do that manually).

Closes #144 