### PR TITLE
[BUILD] Fixed all compiler warnings

### DIFF
--- a/executor/executor.c
+++ b/executor/executor.c
@@ -395,7 +395,7 @@ static void run_challenges() {
             outputs.payload[i] = "Fatal error";
             continue;
         }
-        int ret_len;
+        long ret_len;
         const char* c_ret = PyUnicode_AsUTF8AndSize(ret_string, &ret_len);
         Py_DECREF(ret_string);
         outputs.payload[i] = malloc(ret_len + 1);

--- a/logger/logger.c
+++ b/logger/logger.c
@@ -294,7 +294,7 @@ void log_printf(log_level_t level, char* format, ...) {
     ret = vsnprintf(msg, sizeof(msg), format, args);
     if (ret < 0) {
         printf("ERROR: vsnprintf encountered some error");
-    } else if (ret >= sizeof(msg)) {
+    } else if ((unsigned) ret >= sizeof(msg)) {
         printf("ERROR: log message was too long!");
     }
     va_end(args);

--- a/net_handler/protobuf_tests/devdata_in.c
+++ b/net_handler/protobuf_tests/devdata_in.c
@@ -34,7 +34,7 @@ int main() {
     printf("Received:\n");
     for (int i = 0; i < dev_data->n_devices; i++) {
         printf("Device No. %d: ", i);
-        printf("\ttype = %s, uid = %llu, itype = %d\n", dev_data->devices[i]->name, dev_data->devices[i]->uid, dev_data->devices[i]->type);
+        printf("\ttype = %s, uid = %lu, itype = %d\n", dev_data->devices[i]->name, dev_data->devices[i]->uid, dev_data->devices[i]->type);
         printf("\tParams:\n");
         for (int j = 0; j < dev_data->devices[i]->n_params; j++) {
             printf("\t\tparam \"%s\" has type ", dev_data->devices[i]->params[j]->name);

--- a/net_handler/tcp_conn.c
+++ b/net_handler/tcp_conn.c
@@ -239,7 +239,7 @@ static int recv_new_msg(int conn_fd, int challenge_fd) {
             }
             int err = place_sub_request(req_device->uid, NET_HANDLER, requests);
             if (err == -1) {
-                log_printf(ERROR, "recv_new_msg: Invalid device subscription, device uid %llu is invalid", req_device->uid);
+                log_printf(ERROR, "recv_new_msg: Invalid device subscription, device uid %lu is invalid", req_device->uid);
             }
         }
         dev_data__free_unpacked(dev_data_msg, NULL);

--- a/runtime
+++ b/runtime
@@ -16,10 +16,11 @@ cd $RUNTIME_DIR
 
 case $1 in
     build)
-        pushd shm_wrapper && make && popd
-        pushd net_handler && make && popd
-        pushd executor && make && popd
-        pushd dev_handler && make && popd
+        shift 1
+        pushd shm_wrapper && make $@ && popd
+        pushd net_handler && make $@ && popd
+        pushd executor    && make $@ && popd
+        pushd dev_handler && make $@ && popd
         ;;
 
     run)
@@ -39,9 +40,9 @@ case $1 in
     clean)
         pushd shm_wrapper && make clean && popd
         pushd net_handler && make clean && popd
-        pushd executor && make clean && popd
+        pushd executor    && make clean && popd
         pushd dev_handler && make clean && popd
-        pushd tests && make clean && popd
+        pushd tests       && make clean && popd
         rm -f /tmp/log-fifo
         rm -f /tmp/challenge.sock
         rm -f /tmp/ttyACM*

--- a/shm_wrapper/shm_wrapper.c
+++ b/shm_wrapper/shm_wrapper.c
@@ -277,7 +277,7 @@ void print_dev_ids() {
     } else {
         for (int i = 0; i < MAX_DEVICES; i++) {
             if (catalog & (1 << i)) {
-                printf("dev_ix = %d: type = %d, year = %d, uid = %llu\n", i, dev_ids[i].type, dev_ids[i].year, dev_ids[i].uid);
+                printf("dev_ix = %d: type = %d, year = %d, uid = %lu\n", i, dev_ids[i].type, dev_ids[i].year, dev_ids[i].uid);
             }
         }
     }
@@ -305,7 +305,7 @@ void print_params(uint32_t devices) {
                 printf("Device at index %d with type %d is invalid\n", i, dev_ids[i].type);
                 continue;
             }
-            printf("dev_ix = %d: name = %s, type = %d, year = %d, uid = %llu\n", i, device->name, dev_ids[i].type, dev_ids[i].year, dev_ids[i].uid);
+            printf("dev_ix = %d: name = %s, type = %d, year = %d, uid = %lu\n", i, device->name, dev_ids[i].type, dev_ids[i].year, dev_ids[i].uid);
 
             for (int s = 0; s < 2; s++) {
                 //print out the stream header
@@ -601,7 +601,7 @@ int device_read_uid(uint64_t dev_uid, process_t process, stream_t stream, uint32
 
     // if device doesn't exist, return immediately
     if ((dev_ix = get_dev_ix_from_uid(dev_uid)) == -1) {
-        log_printf(ERROR, "no device at dev_uid = %llu, read failed", dev_uid);
+        log_printf(ERROR, "no device at dev_uid = %lu, read failed", dev_uid);
         return -1;
     }
 
@@ -627,7 +627,7 @@ int device_write_uid(uint64_t dev_uid, process_t process, stream_t stream, uint3
 
     // if device doesn't exist, return immediately
     if ((dev_ix = get_dev_ix_from_uid(dev_uid)) == -1) {
-        log_printf(ERROR, "no device at dev_uid = %llu, write failed", dev_uid);
+        log_printf(ERROR, "no device at dev_uid = %lu, write failed", dev_uid);
         return -1;
     }
 
@@ -646,7 +646,7 @@ int place_sub_request(uint64_t dev_uid, process_t process, uint32_t params_to_su
         return -1;
     }
     if ((dev_ix = get_dev_ix_from_uid(dev_uid)) == -1) {
-        log_printf(ERROR, "no device at dev_uid = %llu, sub request failed", dev_uid);
+        log_printf(ERROR, "no device at dev_uid = %lu, sub request failed", dev_uid);
         return -1;
     }
     curr_sub_map = (process == NET_HANDLER) ? dev_shm_ptr->net_sub_map : dev_shm_ptr->exec_sub_map;

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,4 +1,4 @@
-LIBS := -pthread -lrt -Wall -lprotobuf-c -Wno-format # Ignore formatting warnings (ex: %llu vs %lu)
+LIBS := -pthread -lrt -Wall -lprotobuf-c
 
 CC := gcc
 

--- a/tests/client/net_handler_client.c
+++ b/tests/client/net_handler_client.c
@@ -98,7 +98,7 @@ static void recv_udp_data(int udp_fd) {
     // display the message's fields.
     for (int i = 0; i < dev_data->n_devices; i++) {
         fprintf(udp_output_fp, "Device No. %d:", i);
-        fprintf(udp_output_fp, "\ttype = %s, uid = %llu, itype = %d\n", dev_data->devices[i]->name, dev_data->devices[i]->uid, dev_data->devices[i]->type);
+        fprintf(udp_output_fp, "\ttype = %s, uid = %lu, itype = %d\n", dev_data->devices[i]->name, dev_data->devices[i]->uid, dev_data->devices[i]->type);
         fprintf(udp_output_fp, "\tParams:\n");
         for (int j = 0; j < dev_data->devices[i]->n_params; j++) {
             fprintf(udp_output_fp, "\t\tparam \"%s\" has type ", dev_data->devices[i]->params[j]->name);


### PR DESCRIPTION
Fixed all the compiler warnings. Couldn't figure out a nice/easy way to have `uint64_t` have the correct print formatter on both Windows and Linux so I chose to stick with the Linux default of `%lu` for `uint64_t`, where before we used the Windows default of `%llu`. There is one way of doing it using `inttypes.h` but its not very elegant. 

Also, I changed the `./runtime build` command to pass any arguments so now to force a rebuild, you can just run `./runtime build -B`.