### PR TITLE
[NET_HANDLER] Fix memory leak in send_log_msg()

### DIFF
--- a/net_handler/tcp_conn.c
+++ b/net_handler/tcp_conn.c
@@ -69,15 +69,22 @@ static void send_log_msg(int conn_fd, FILE* log_file) {
             strcpy(log_msg.payload[log_msg.n_payload], nextline);
             log_msg.n_payload++;
         } else if (feof(log_file) != 0) {  // All write ends of FIFO are closed, don't send any more logs
+            // It's expected that all write ends are closed only when processes with logger_init() are killed
             if (log_msg.n_payload != 0) {  //if a few last logs to send, break to send those logs
                 break;
-            } else {  //otherwise, return immediately
+            } else {  // log_msg.n_payload == 0;  (payload is empty) Return immediately
+                free(log_msg.payload);
                 return;
             }
         } else if (errno == EAGAIN || errno == EWOULDBLOCK) {  // No more to read on pipe (would block in a blocking read)
             break;
         } else {  // Error occurred
             log_printf(ERROR, "send_log_msg: Error reading from log fifo: %s", strerror(errno));
+            // Free loaded payload contents and the payload itself
+            for (int i = 0; i < log_msg.n_payload; i++) {
+                free(log_msg.payload[i]);
+            }
+            free(log_msg.payload);
             return;
         }
     }
@@ -296,8 +303,8 @@ static void* tcp_process(void* tcp_args) {
         //deny all cancellation requests until the next loop
         pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, NULL);
 
-        //send a new log message if one is available and we want to send logs
-        if (args->send_logs && FD_ISSET(log_fd, &read_set)) {
+        // If client wants logs, logs are availble to send, and FIFO doesn't have an EOF, send logs
+        if (args->send_logs && FD_ISSET(log_fd, &read_set) && feof(args->log_file) != 0) {
             send_log_msg(args->conn_fd, args->log_file);
         }
 


### PR DESCRIPTION
- Free all allocated memory before returning
- Call function iff FIFO does not have an EOF

Resolves #136 -- We were not properly `free()`ing memory before returning

Finding this bug made it clear that `tcp_conn.c` is still being spammed with `EOF`, even though not all write-ends are closed.
As a result, we re-opened #82