### PR TITLE
[LOWCAR] Working and tuned KoalaBear PID control and acceleration

### DIFF
--- a/lowcar/devices/Device/Messenger.cpp
+++ b/lowcar/devices/Device/Messenger.cpp
@@ -144,18 +144,18 @@ void Messenger::lowcar_printf(char* format, ...) {
 }
 
 void Messenger::lowcar_print_float(char* name, float val) {
-	char sign = (val < 0.0) ? '-' : ' ';				 // Holds sign of the value
-	if (val < 0.0) {
-		val *= -1.0;
-	}
+    char sign = (val < 0.0) ? '-' : ' ';  // Holds sign of the value
+    if (val < 0.0) {
+        val *= -1.0;
+    }
     int whole_val = (int) val;                           // Part of val to the left of the decimal point
     int thousandths = (int) ((val - whole_val) * 1000);  // The 3 digits to the right of the decimal point
-	
-	if (sign == '-') {
-		this->lowcar_printf("%s: %c%d.%03d", name, sign, whole_val, thousandths);
-	} else {
-	    this->lowcar_printf("%s:%c%d.%03d", name, sign, whole_val, thousandths);
-	}
+
+    if (sign == '-') {
+        this->lowcar_printf("%s: %c%d.%03d", name, sign, whole_val, thousandths);
+    } else {
+        this->lowcar_printf("%s:%c%d.%03d", name, sign, whole_val, thousandths);
+    }
 }
 
 void Messenger::lowcar_flush() {

--- a/lowcar/devices/Device/Messenger.cpp
+++ b/lowcar/devices/Device/Messenger.cpp
@@ -144,9 +144,18 @@ void Messenger::lowcar_printf(char* format, ...) {
 }
 
 void Messenger::lowcar_print_float(char* name, float val) {
+	char sign = (val < 0.0) ? '-' : ' ';				 // Holds sign of the value
+	if (val < 0.0) {
+		val *= -1.0;
+	}
     int whole_val = (int) val;                           // Part of val to the left of the decimal point
     int thousandths = (int) ((val - whole_val) * 1000);  // The 3 digits to the right of the decimal point
-    this->lowcar_printf("%s: %d.%03d", name, whole_val, thousandths);
+	
+	if (sign == '-') {
+		this->lowcar_printf("%s: %c%d.%03d", name, sign, whole_val, thousandths);
+	} else {
+	    this->lowcar_printf("%s:%c%d.%03d", name, sign, whole_val, thousandths);
+	}
 }
 
 void Messenger::lowcar_flush() {

--- a/lowcar/devices/KoalaBear/KoalaBear.cpp
+++ b/lowcar/devices/KoalaBear/KoalaBear.cpp
@@ -328,7 +328,7 @@ void KoalaBear::device_actions() {
 	if (this->velocity_b == 0.0 && adjusted_velocity_b < this->deadband_b && adjusted_velocity_b > (this->deadband_b * -1.0)) {
 		this->curr_velocity_b = adjusted_velocity_b = 0.0;
 	}
-
+	
     // compute the actual duty cycle to command the motors at (depending on whether pid is enabled)
     if (this->pid_enabled_a) {
         this->pid_a->set_velocity(adjusted_velocity_a);

--- a/lowcar/devices/KoalaBear/KoalaBear.cpp
+++ b/lowcar/devices/KoalaBear/KoalaBear.cpp
@@ -35,7 +35,7 @@ uint16_t torque_read_data;
 // --------------------------------------------------------------------------------------------
 
 // --------------------> CHANGE THIS TO IMPLEMENT ACCELERATION FOR KARTS <---------------------
-#define ACCEL 0.7			// acceleration of motors, in duty cycle units per second squared
+#define ACCEL 0.7  // acceleration of motors, in duty cycle units per second squared
 // --------------------------------------------------------------------------------------------
 
 // default values for PID controllers; PID control is explained in the Wiki!
@@ -106,7 +106,7 @@ KoalaBear::KoalaBear() : Device(DeviceType::KOALA_BEAR, 13) {
     this->velocity_a = this->velocity_b = 0.0;
     this->deadband_a = this->deadband_b = 0.05;
     this->invert_a = this->invert_b = FALSE;  // by default, motor directions are not inverted
-	this->curr_velocity_a = this->curr_velocity_b = 0.0;
+    this->curr_velocity_a = this->curr_velocity_b = 0.0;
 
     // initialize encoders
     enc_a = enc_b = 0.0;
@@ -123,7 +123,7 @@ KoalaBear::KoalaBear() : Device(DeviceType::KOALA_BEAR, 13) {
     this->led = new LEDKoala();
     this->prev_led_time = this->prev_loop_time = millis();
     this->curr_led_mtr = MTRA;
-	this->online = FALSE;
+    this->online = FALSE;
 }
 
 size_t KoalaBear::device_read(uint8_t param, uint8_t* data_buf) {
@@ -215,11 +215,11 @@ size_t KoalaBear::device_write(uint8_t param, uint8_t* data_buf) {
             this->pid_a->set_coefficients(this->pid_a->get_kp(), this->pid_a->get_ki(), ((double*) data_buf)[0]);
             return sizeof(float);
         case ENC_A:
-			// detaching the interrupt here prevets race codition on enc_a variable between this and the interrupt service routine
-			detachInterrupt(digitalPinToInterrupt(AENC1));
+            // detaching the interrupt here prevets race codition on enc_a variable between this and the interrupt service routine
+            detachInterrupt(digitalPinToInterrupt(AENC1));
             enc_a = ((int32_t*) data_buf)[0];
             this->pid_a->set_position((float) enc_a);
-		    attachInterrupt(digitalPinToInterrupt(AENC1), handle_enc_a_tick, RISING);
+            attachInterrupt(digitalPinToInterrupt(AENC1), handle_enc_a_tick, RISING);
             return sizeof(int32_t);
 
         // Params for Motor B
@@ -248,11 +248,11 @@ size_t KoalaBear::device_write(uint8_t param, uint8_t* data_buf) {
             this->pid_b->set_coefficients(this->pid_b->get_kp(), this->pid_b->get_ki(), ((double*) data_buf)[0]);
             return sizeof(float);
         case ENC_B:
-			// detaching the interrupt here prevets race codition on enc_b variable between this and the interrupt service routine
-			detachInterrupt(digitalPinToInterrupt(BENC1));
+            // detaching the interrupt here prevets race codition on enc_b variable between this and the interrupt service routine
+            detachInterrupt(digitalPinToInterrupt(BENC1));
             enc_b = ((int32_t*) data_buf)[0];
             this->pid_b->set_position((float) enc_b);
-		    attachInterrupt(digitalPinToInterrupt(BENC1), handle_enc_b_tick, RISING);
+            attachInterrupt(digitalPinToInterrupt(BENC1), handle_enc_b_tick, RISING);
             return sizeof(int32_t);
         default:
             return 0;
@@ -287,25 +287,25 @@ void KoalaBear::device_reset() {
 
     this->velocity_a = 0.0;
     this->velocity_b = 0.0;
-	this->curr_velocity_a = 0.0;
-	this->curr_velocity_b = 0.0;
+    this->curr_velocity_a = 0.0;
+    this->curr_velocity_b = 0.0;
     this->pid_enabled_a = TRUE;
     this->pid_enabled_b = TRUE;
-	this->online = FALSE;
+    this->online = FALSE;
 }
 
 void KoalaBear::device_actions() {
-	// if we just got started looping, save a value for prev_loop_time and immediately return
-	// prevents extremely large interval_secs (and therefore large extraneous motions on startup)
-	if (!this->online) {
-		this->prev_loop_time = millis();
-		this->online = TRUE;
-		return;
-	}
-	
+    // if we just got started looping, save a value for prev_loop_time and immediately return
+    // prevents extremely large interval_secs (and therefore large extraneous motions on startup)
+    if (!this->online) {
+        this->prev_loop_time = millis();
+        this->online = TRUE;
+        return;
+    }
+
     float duty_cycle_a, duty_cycle_b, adjusted_velocity_a, adjusted_velocity_b;
     unsigned long curr_time = millis();
-	float interval_secs = ((float) (curr_time - this->prev_loop_time)) / 1000.0;		// compute time passed between loops, in seconds
+    float interval_secs = ((float) (curr_time - this->prev_loop_time)) / 1000.0;  // compute time passed between loops, in seconds
 
     // switch between displaying info about MTRA and MTRB every 2 seconds
     if (curr_time - this->prev_led_time > 2000) {
@@ -319,22 +319,22 @@ void KoalaBear::device_actions() {
     }
 
     // compute the actual target speed of motors (depending on whether direction is inverted, max duty cycle, and acceleration)
-	// acceleration calculation: delta V = sign(V) * a * delta t
-	this->curr_velocity_a = this->curr_velocity_a + (((this->velocity_a - this->curr_velocity_a > 0) ? 1.0 : -1.0) * ACCEL * interval_secs);
-	this->curr_velocity_b = this->curr_velocity_b + (((this->velocity_b - this->curr_velocity_b > 0) ? 1.0 : -1.0) * ACCEL * interval_secs);
-		
-	// inversion and max duty cycle calculation
+    // acceleration calculation: delta V = sign(V) * a * delta t
+    this->curr_velocity_a = this->curr_velocity_a + (((this->velocity_a - this->curr_velocity_a > 0) ? 1.0 : -1.0) * ACCEL * interval_secs);
+    this->curr_velocity_b = this->curr_velocity_b + (((this->velocity_b - this->curr_velocity_b > 0) ? 1.0 : -1.0) * ACCEL * interval_secs);
+
+    // inversion and max duty cycle calculation
     adjusted_velocity_a = MAX_DUTY_CYCLE * ((this->invert_a) ? this->curr_velocity_a * -1.0 : this->curr_velocity_a);
     adjusted_velocity_b = MAX_DUTY_CYCLE * ((this->invert_b) ? this->curr_velocity_b * -1.0 : this->curr_velocity_b);
-	
-	// this logic makes sure that the robot doesn't oscillate around 0 when the student wants the robot to stop
-	if (this->velocity_a == 0.0 && adjusted_velocity_a < this->deadband_a && adjusted_velocity_a > (this->deadband_a * -1.0)) {
-		this->curr_velocity_a = adjusted_velocity_a = 0.0;
-	}
-	if (this->velocity_b == 0.0 && adjusted_velocity_b < this->deadband_b && adjusted_velocity_b > (this->deadband_b * -1.0)) {
-		this->curr_velocity_b = adjusted_velocity_b = 0.0;
-	}
-	
+
+    // this logic makes sure that the robot doesn't oscillate around 0 when the student wants the robot to stop
+    if (this->velocity_a == 0.0 && adjusted_velocity_a < this->deadband_a && adjusted_velocity_a > (this->deadband_a * -1.0)) {
+        this->curr_velocity_a = adjusted_velocity_a = 0.0;
+    }
+    if (this->velocity_b == 0.0 && adjusted_velocity_b < this->deadband_b && adjusted_velocity_b > (this->deadband_b * -1.0)) {
+        this->curr_velocity_b = adjusted_velocity_b = 0.0;
+    }
+
     // compute the actual duty cycle to command the motors at (depending on whether pid is enabled)
     if (this->pid_enabled_a) {
         this->pid_a->set_velocity(adjusted_velocity_a);
@@ -357,9 +357,9 @@ void KoalaBear::device_actions() {
     // send computed duty cycle commands to motors
     drive(duty_cycle_a, MTRA);
     drive(duty_cycle_b, MTRB);
-	
-	// update prev_loop_time
-	this->prev_loop_time = curr_time;
+
+    // update prev_loop_time
+    this->prev_loop_time = curr_time;
 }
 
 //************************* KOALABEAR HELPER FUNCTIONS *************************//

--- a/lowcar/devices/KoalaBear/KoalaBear.cpp
+++ b/lowcar/devices/KoalaBear/KoalaBear.cpp
@@ -31,12 +31,16 @@ uint16_t torque_read_data;
 //******************************* KOALABEAR CONSTANTS AND PARAMS ****************************//
 
 // ----------------------> CHANGE THIS TO IMPLEMENT MAX SPEED FOR KARTS <----------------------
-#define MAX_DUTY_CYCLE 0.5  // maximum duty cycle to cap how fast the motors can go: range (0, 1]
+#define MAX_DUTY_CYCLE 1.0  // maximum duty cycle to cap how fast the motors can go: range (0, 1]
+// --------------------------------------------------------------------------------------------
+
+// --------------------> CHANGE THIS TO IMPLEMENT ACCELERATION FOR KARTS <---------------------
+#define ACCEL 1.0			// acceleration of motors, in duty cycle units per second squared
 // --------------------------------------------------------------------------------------------
 
 // default values for PID controllers; PID control is explained in the Wiki!
-#define KP_DEFAULT 0.035
-#define KI_DEFAULT 0.005
+#define KP_DEFAULT 0.25
+#define KI_DEFAULT 0.0
 #define KD_DEFAULT 0.0
 
 typedef enum {
@@ -102,6 +106,7 @@ KoalaBear::KoalaBear() : Device(DeviceType::KOALA_BEAR, 13) {
     this->velocity_a = this->velocity_b = 0.0;
     this->deadband_a = this->deadband_b = 0.05;
     this->invert_a = this->invert_b = FALSE;  // by default, motor directions are not inverted
+	this->curr_velocity_a = this->curr_velocity_b = 0.0;
 
     // initialize encoders
     enc_a = enc_b = 0.0;
@@ -111,13 +116,14 @@ KoalaBear::KoalaBear() : Device(DeviceType::KOALA_BEAR, 13) {
     // initialize PID controllers
     this->pid_a = new PID();
     this->pid_b = new PID();
-    this->pid_enabled_a = this->pid_enabled_b = TRUE;  // by default, PID control is enabled
+    this->pid_enabled_a = this->pid_enabled_b = FALSE;  // by default, PID control is enabled
     this->pid_a->set_coefficients(KP_DEFAULT, KI_DEFAULT, KD_DEFAULT);
     this->pid_b->set_coefficients(KP_DEFAULT, KI_DEFAULT, KD_DEFAULT);
 
     this->led = new LEDKoala();
-    this->prev_led_time = millis();
+    this->prev_led_time = this->prev_loop_time = millis();
     this->curr_led_mtr = MTRA;
+	this->online = FALSE;
 }
 
 size_t KoalaBear::device_read(uint8_t param, uint8_t* data_buf) {
@@ -275,13 +281,25 @@ void KoalaBear::device_reset() {
 
     this->velocity_a = 0.0;
     this->velocity_b = 0.0;
+	this->curr_velocity_a = 0.0;
+	this->curr_velocity_b = 0.0;
     this->pid_enabled_a = TRUE;
     this->pid_enabled_b = TRUE;
+	this->online = FALSE;
 }
 
 void KoalaBear::device_actions() {
+	// if we just got started looping, save a value for prev_loop_time and immediately return
+	// prevents extremely large interval_secs (and therefore large extraneous motions on startup)
+	if (!this->online) {
+		this->prev_loop_time = millis();
+		this->online = TRUE;
+		return;
+	}
+	
     float duty_cycle_a, duty_cycle_b, adjusted_velocity_a, adjusted_velocity_b;
     unsigned long curr_time = millis();
+	float interval_secs = ((float) (curr_time - this->prev_loop_time)) / 1000.0;		// compute time passed between loops, in seconds
 
     // switch between displaying info about MTRA and MTRB every 2 seconds
     if (curr_time - this->prev_led_time > 2000) {
@@ -295,9 +313,21 @@ void KoalaBear::device_actions() {
     }
 
     // compute the actual target speed of motors (depending on whether direction is inverted, max duty cycle, and acceleration)
-    // TODO: some acceleration calculation here too
-    adjusted_velocity_a = MAX_DUTY_CYCLE * ((this->invert_a) ? this->velocity_a * -1.0 : this->velocity_a);
-    adjusted_velocity_b = MAX_DUTY_CYCLE * ((this->invert_b) ? this->velocity_b * -1.0 : this->velocity_b);
+	// acceleration calculation
+	this->curr_velocity_a = this->curr_velocity_a + (ACCEL * ((this->velocity_a - this->curr_velocity_a > 0) ? 1.0 : -1.0) * interval_secs);
+	this->curr_velocity_b = this->curr_velocity_b + (ACCEL * ((this->velocity_b - this->curr_velocity_b > 0) ? 1.0 : -1.0) * interval_secs);
+		
+	// inversion and max duty cycle calculation
+    adjusted_velocity_a = MAX_DUTY_CYCLE * ((this->invert_a) ? this->curr_velocity_a * -1.0 : this->curr_velocity_a);
+    adjusted_velocity_b = MAX_DUTY_CYCLE * ((this->invert_b) ? this->curr_velocity_b * -1.0 : this->curr_velocity_b);
+	
+	// this logic makes sure that the robot doesn't oscillate around 0 when the student wants the robot to stop
+	if (this->velocity_a == 0.0 && adjusted_velocity_a < this->deadband_a && adjusted_velocity_a > (this->deadband_a * -1.0)) {
+		this->curr_velocity_a = adjusted_velocity_a = 0.0;
+	}
+	if (this->velocity_b == 0.0 && adjusted_velocity_b < this->deadband_b && adjusted_velocity_b > (this->deadband_b * -1.0)) {
+		this->curr_velocity_b = adjusted_velocity_b = 0.0;
+	}
 
     // compute the actual duty cycle to command the motors at (depending on whether pid is enabled)
     if (this->pid_enabled_a) {
@@ -321,6 +351,9 @@ void KoalaBear::device_actions() {
     // send computed duty cycle commands to motors
     drive(duty_cycle_a, MTRA);
     drive(duty_cycle_b, MTRB);
+	
+	// update prev_loop_time
+	this->prev_loop_time = curr_time;
 }
 
 //************************* KOALABEAR HELPER FUNCTIONS *************************//

--- a/lowcar/devices/KoalaBear/KoalaBear.h
+++ b/lowcar/devices/KoalaBear/KoalaBear.h
@@ -35,12 +35,15 @@ class KoalaBear : public Device {
     virtual void device_actions();
 
   private:
-    float velocity_a, velocity_b;          // student-specified velocities of motors, range [-1.0, 1.0]
-    float deadband_a, deadband_b;          // deadbands of motors
-    uint8_t invert_a, invert_b;            // true if Motor A should rotate in opposite direction of default; false for default direction
-    uint8_t pid_enabled_a, pid_enabled_b;  // true if using PID control; false if using manual drive mode
-    PID *pid_a, *pid_b;                    // PID controllers for motors
-    LEDKoala* led;                         // for controlling the KoalaBear LED
+    float velocity_a, velocity_b;           // student-specified velocities of motors, range [-1.0, 1.0]
+    float deadband_a, deadband_b;           // deadbands of motors
+    uint8_t invert_a, invert_b;             // true if Motor A should rotate in opposite direction of default; false for default direction
+    uint8_t pid_enabled_a, pid_enabled_b;   // true if using PID control; false if using manual drive mode
+    float curr_velocity_a, curr_velocity_b; // current velocity of motors
+    unsigned long prev_loop_time;           // for calculating acceleration
+    uint8_t online;                         // true if controller is online and in nominal loop; false otherwise
+    PID *pid_a, *pid_b;                     // PID controllers for motors
+    LEDKoala* led;                          // for controlling the KoalaBear LED
     unsigned long prev_led_time;
     int curr_led_mtr;
 

--- a/lowcar/devices/KoalaBear/KoalaBear.h
+++ b/lowcar/devices/KoalaBear/KoalaBear.h
@@ -35,15 +35,15 @@ class KoalaBear : public Device {
     virtual void device_actions();
 
   private:
-    float velocity_a, velocity_b;           // student-specified velocities of motors, range [-1.0, 1.0]
-    float deadband_a, deadband_b;           // deadbands of motors
-    uint8_t invert_a, invert_b;             // true if Motor A should rotate in opposite direction of default; false for default direction
-    uint8_t pid_enabled_a, pid_enabled_b;   // true if using PID control; false if using manual drive mode
-    float curr_velocity_a, curr_velocity_b; // current velocity of motors
-    unsigned long prev_loop_time;           // for calculating acceleration
-    uint8_t online;                         // true if controller is online and in nominal loop; false otherwise
-    PID *pid_a, *pid_b;                     // PID controllers for motors
-    LEDKoala* led;                          // for controlling the KoalaBear LED
+    float velocity_a, velocity_b;            // student-specified velocities of motors, range [-1.0, 1.0]
+    float deadband_a, deadband_b;            // deadbands of motors
+    uint8_t invert_a, invert_b;              // true if Motor A should rotate in opposite direction of default; false for default direction
+    uint8_t pid_enabled_a, pid_enabled_b;    // true if using PID control; false if using manual drive mode
+    float curr_velocity_a, curr_velocity_b;  // current velocity of motors
+    unsigned long prev_loop_time;            // for calculating acceleration
+    uint8_t online;                          // true if controller is online and in nominal loop; false otherwise
+    PID *pid_a, *pid_b;                      // PID controllers for motors
+    LEDKoala* led;                           // for controlling the KoalaBear LED
     unsigned long prev_led_time;
     int curr_led_mtr;
 

--- a/lowcar/devices/KoalaBear/PID.cpp
+++ b/lowcar/devices/KoalaBear/PID.cpp
@@ -2,6 +2,7 @@
 
 #define MAX_TPS 2700.0  // maximum encoder ticks per second that a motor can go (determined empirically)
 #define SAMPLES 5		// number of samples for calculating the derivative
+#define ONE_MILLION 1000000.0
 
 PID::PID() {
     this->kp = this->ki = this->kd = 0.0;
@@ -9,17 +10,18 @@ PID::PID() {
     this->integral = 0.0;
     this->velocity = 0.0;
 	
+	// create and populate the prev_error and prev_time arrays
 	this->prev_error = new float[SAMPLES];
-    this->prev_time = new unsigned long[SAMPLES];
+    this->prev_time = new float[SAMPLES];
 	for (int i = 0; i < SAMPLES; i++) {
 		this->prev_error[i] = 0.0;
-		this->prev_time[i] = micros();
+		this->prev_time[i] = ((float) micros()) / ONE_MILLION;
 	}
 }
 
 float PID::compute(float curr_pos) {
-    unsigned long curr_time = micros();                                                              // get the current time
-    float interval_secs = ((float) (curr_time - this->prev_time[SAMPLES - 1])) / 1000000.0;          // compute time passed between loops, in seconds
+    float curr_time = ((float) micros()) / ONE_MILLION;                                       		 // get the current time, in seconds
+    float interval_secs = curr_time - this->prev_time[SAMPLES - 1];          						 // compute time passed between loops, in seconds
     float desired_pos = this->prev_desired_pos + (velocity_to_tps(this->velocity) * interval_secs);  // compute the desired position at this time
     float error = desired_pos - curr_pos;                                                            // compute the error as the set point (desired position) - process variable (current position)
     this->integral += error * interval_secs;                                                         // compute the new value of this->integral using right-rectangle approximation
@@ -42,6 +44,7 @@ float PID::compute(float curr_pos) {
     // if target speed is 0, output 0 automatically (prevent jittering when motor stopped) and reset integral to 0
     if (this->velocity == 0.0) {
         this->integral = 0.0;
+		this->prev_desired_pos = curr_pos; // this will flush out the values in the error array
         return 0.0;
     } else {
         return output;
@@ -59,10 +62,13 @@ void PID::set_velocity(float velocity) {
 }
 
 // used when student sets encoder to a certain value
+// resets all of the PID controller values
 void PID::set_position(float curr_pos) {
-    this->prev_pos = curr_pos;
+    this->prev_pos = this->prev_desired_pos = curr_pos;
 	for (int i = 0; i < SAMPLES - 1; i++) {
-		this->prev_error[i] = 0.0; // resets the error too
+		this->prev_error[i] = 0.0;
+		this->prev_time[i] = ((float) micros()) / ONE_MILLION;
+		this->integral = 0.0;
 	}
 }
 
@@ -90,22 +96,17 @@ float PID::average(float nums[], int i) {
 
 // calculate the slope of least-squares linear regression through points
 // "number" is the number of elements in the arrays
-float PID::regression(unsigned long x_vals[], float y_vals[], int number) {
+float PID::regression(float x_vals[], float y_vals[], int number) {
     float x_avg, y_avg, slope;
-    float numerator[number], denominator[number], x_vals_float[number];
-	
-	// convert inputted x_vals to floats
-	for (int i = 0; i < number; i++) {
-		x_vals_float[i] = (float) x_vals[i];
-	}
+    float numerator[number], denominator[number];
 	
     //calculate averages
-    x_avg = average(x_vals_float, number);
+    x_avg = average(x_vals, number);
     y_avg = average(y_vals, number); 
 
     for (int i = 0; i < number; i++) {
-        numerator[i] = ((x_vals_float[i] - x_avg) * (y_vals[i] - y_avg));			// (x_i - x_avg) * (y_i - y_avg)
-        denominator[i] = ((x_vals_float[i] - x_avg) * (x_vals_float[i] - x_avg));	// (x_i - x_avg) ^ 2
+        numerator[i] = ((x_vals[i] - x_avg) * (y_vals[i] - y_avg));	// (x_i - x_avg) * (y_i - y_avg)
+        denominator[i] = ((x_vals[i] - x_avg) * (x_vals[i] - x_avg));	// (x_i - x_avg) ^ 2
     }
     slope = (sum(numerator, number) / sum(denominator, number)); 
 

--- a/lowcar/devices/KoalaBear/PID.cpp
+++ b/lowcar/devices/KoalaBear/PID.cpp
@@ -1,30 +1,43 @@
 #include "PID.h"
 
 #define MAX_TPS 2700.0  // maximum encoder ticks per second that a motor can go (determined empirically)
+#define SAMPLES 5		// number of samples for calculating the derivative
 
 PID::PID() {
     this->kp = this->ki = this->kd = 0.0;
-    this->prev_error = this->prev_pos = this->prev_desired_pos = 0.0;
+    this->prev_pos = this->prev_desired_pos = 0.0;
     this->integral = 0.0;
     this->velocity = 0.0;
-    this->prev_time = micros();
+	
+	this->prev_error = new float[SAMPLES];
+    this->prev_time = new unsigned long[SAMPLES];
+	for (int i = 0; i < SAMPLES; i++) {
+		this->prev_error[i] = 0.0;
+		this->prev_time[i] = micros();
+	}
 }
 
 float PID::compute(float curr_pos) {
     unsigned long curr_time = micros();                                                              // get the current time
-    float interval_secs = ((float) (curr_time - this->prev_time)) / 1000000.0;                       // compute time passed between loops, in seconds
+    float interval_secs = ((float) (curr_time - this->prev_time[SAMPLES - 1])) / 1000000.0;          // compute time passed between loops, in seconds
     float desired_pos = this->prev_desired_pos + (velocity_to_tps(this->velocity) * interval_secs);  // compute the desired position at this time
     float error = desired_pos - curr_pos;                                                            // compute the error as the set point (desired position) - process variable (current position)
     this->integral += error * interval_secs;                                                         // compute the new value of this->integral using right-rectangle approximation
+	
+	// shift the prev_error and prev_time arrays and insert curr_time and error
+	for (int i = 0; i < SAMPLES - 1; i++) {
+		this->prev_error[i] = this->prev_error[i + 1];
+		this->prev_time[i] = this->prev_time[i + 1];
+	}
+	this->prev_error[SAMPLES - 1] = error;
+	this->prev_time[SAMPLES - 1] = curr_time;
 
     // output = kp * error + ki * integral of error * kd * "derivative" of error
-    float output = (this->kp * error) + (this->ki * this->integral) + (this->kd * ((error - this->prev_error) / interval_secs));
+    float output = (this->kp * error) + (this->ki * this->integral) + (this->kd * regression(this->prev_time, this->prev_error, SAMPLES));
 
     // store the current values into previous values for use on next loop
-    this->prev_error = error;
     this->prev_pos = curr_pos;
     this->prev_desired_pos = desired_pos;
-    this->prev_time = curr_time;
 
     // if target speed is 0, output 0 automatically (prevent jittering when motor stopped) and reset integral to 0
     if (this->velocity == 0.0) {
@@ -48,7 +61,9 @@ void PID::set_velocity(float velocity) {
 // used when student sets encoder to a certain value
 void PID::set_position(float curr_pos) {
     this->prev_pos = curr_pos;
-    this->prev_error = 0.0;  // resets the error too
+	for (int i = 0; i < SAMPLES - 1; i++) {
+		this->prev_error[i] = 0.0; // resets the error too
+	}
 }
 
 // three getter functions for the three coefficients
@@ -57,6 +72,45 @@ float PID::get_ki() { return this->ki; }
 float PID::get_kd() { return this->kd; }
 
 // *********************** HELPER FUNCTIONS *********************** //
+
+// find the sum of the given floats
+float PID::sum(float nums[], int i) {
+	float total = 0.0;
+	for (int x = 0; x < i; x++) {
+		total += nums[x];
+	}
+	return total;
+}
+
+// find the average of the given floats
+float PID::average(float nums[], int i) {
+	float total = sum(nums, i);
+	return (total / (float)i);
+}
+
+// calculate the slope of least-squares linear regression through points
+// "number" is the number of elements in the arrays
+float PID::regression(unsigned long x_vals[], float y_vals[], int number) {
+    float x_avg, y_avg, slope;
+    float numerator[number], denominator[number], x_vals_float[number];
+	
+	// convert inputted x_vals to floats
+	for (int i = 0; i < number; i++) {
+		x_vals_float[i] = (float) x_vals[i];
+	}
+	
+    //calculate averages
+    x_avg = average(x_vals_float, number);
+    y_avg = average(y_vals, number); 
+
+    for (int i = 0; i < number; i++) {
+        numerator[i] = ((x_vals_float[i] - x_avg) * (y_vals[i] - y_avg));			// (x_i - x_avg) * (y_i - y_avg)
+        denominator[i] = ((x_vals_float[i] - x_avg) * (x_vals_float[i] - x_avg));	// (x_i - x_avg) ^ 2
+    }
+    slope = (sum(numerator, number) / sum(denominator, number)); 
+
+    return slope;
+}
 
 float PID::velocity_to_tps(float velocity) {
     return MAX_TPS * velocity;

--- a/lowcar/devices/KoalaBear/PID.cpp
+++ b/lowcar/devices/KoalaBear/PID.cpp
@@ -1,7 +1,7 @@
 #include "PID.h"
 
 #define MAX_TPS 2700.0  // maximum encoder ticks per second that a motor can go (determined empirically)
-#define SAMPLES 5		// number of samples for calculating the derivative
+#define SAMPLES 5       // number of samples for calculating the derivative
 #define ONE_MILLION 1000000.0
 
 PID::PID() {
@@ -9,30 +9,30 @@ PID::PID() {
     this->prev_pos = this->prev_desired_pos = 0.0;
     this->integral = 0.0;
     this->velocity = 0.0;
-	
-	// create and populate the prev_error and prev_time arrays
-	this->prev_error = new float[SAMPLES];
+
+    // create and populate the prev_error and prev_time arrays
+    this->prev_error = new float[SAMPLES];
     this->prev_time = new float[SAMPLES];
-	for (int i = 0; i < SAMPLES; i++) {
-		this->prev_error[i] = 0.0;
-		this->prev_time[i] = ((float) micros()) / ONE_MILLION;
-	}
+    for (int i = 0; i < SAMPLES; i++) {
+        this->prev_error[i] = 0.0;
+        this->prev_time[i] = ((float) micros()) / ONE_MILLION;
+    }
 }
 
 float PID::compute(float curr_pos) {
-    float curr_time = ((float) micros()) / ONE_MILLION;                                       		 // get the current time, in seconds
-    float interval_secs = curr_time - this->prev_time[SAMPLES - 1];          						 // compute time passed between loops, in seconds
+    float curr_time = ((float) micros()) / ONE_MILLION;                                              // get the current time, in seconds
+    float interval_secs = curr_time - this->prev_time[SAMPLES - 1];                                  // compute time passed between loops, in seconds
     float desired_pos = this->prev_desired_pos + (velocity_to_tps(this->velocity) * interval_secs);  // compute the desired position at this time
     float error = desired_pos - curr_pos;                                                            // compute the error as the set point (desired position) - process variable (current position)
     this->integral += error * interval_secs;                                                         // compute the new value of this->integral using right-rectangle approximation
-	
-	// shift the prev_error and prev_time arrays and insert curr_time and error
-	for (int i = 0; i < SAMPLES - 1; i++) {
-		this->prev_error[i] = this->prev_error[i + 1];
-		this->prev_time[i] = this->prev_time[i + 1];
-	}
-	this->prev_error[SAMPLES - 1] = error;
-	this->prev_time[SAMPLES - 1] = curr_time;
+
+    // shift the prev_error and prev_time arrays and insert curr_time and error
+    for (int i = 0; i < SAMPLES - 1; i++) {
+        this->prev_error[i] = this->prev_error[i + 1];
+        this->prev_time[i] = this->prev_time[i + 1];
+    }
+    this->prev_error[SAMPLES - 1] = error;
+    this->prev_time[SAMPLES - 1] = curr_time;
 
     // output = kp * error + ki * integral of error * kd * "derivative" of error
     float output = (this->kp * error) + (this->ki * this->integral) + (this->kd * regression(this->prev_time, this->prev_error, SAMPLES));
@@ -44,7 +44,7 @@ float PID::compute(float curr_pos) {
     // if target speed is 0, output 0 automatically (prevent jittering when motor stopped) and reset integral to 0
     if (this->velocity == 0.0) {
         this->integral = 0.0;
-		this->prev_desired_pos = curr_pos; // this will flush out the values in the error array
+        this->prev_desired_pos = curr_pos;  // this will flush out the values in the error array
         return 0.0;
     } else {
         return output;
@@ -65,11 +65,11 @@ void PID::set_velocity(float velocity) {
 // resets all of the PID controller values
 void PID::set_position(float curr_pos) {
     this->prev_pos = this->prev_desired_pos = curr_pos;
-	for (int i = 0; i < SAMPLES - 1; i++) {
-		this->prev_error[i] = 0.0;
-		this->prev_time[i] = ((float) micros()) / ONE_MILLION;
-		this->integral = 0.0;
-	}
+    for (int i = 0; i < SAMPLES - 1; i++) {
+        this->prev_error[i] = 0.0;
+        this->prev_time[i] = ((float) micros()) / ONE_MILLION;
+        this->integral = 0.0;
+    }
 }
 
 // three getter functions for the three coefficients
@@ -81,17 +81,17 @@ float PID::get_kd() { return this->kd; }
 
 // find the sum of the given floats
 float PID::sum(float nums[], int i) {
-	float total = 0.0;
-	for (int x = 0; x < i; x++) {
-		total += nums[x];
-	}
-	return total;
+    float total = 0.0;
+    for (int x = 0; x < i; x++) {
+        total += nums[x];
+    }
+    return total;
 }
 
 // find the average of the given floats
 float PID::average(float nums[], int i) {
-	float total = sum(nums, i);
-	return (total / (float)i);
+    float total = sum(nums, i);
+    return (total / (float) i);
 }
 
 // calculate the slope of least-squares linear regression through points
@@ -99,16 +99,16 @@ float PID::average(float nums[], int i) {
 float PID::regression(float x_vals[], float y_vals[], int number) {
     float x_avg, y_avg, slope;
     float numerator[number], denominator[number];
-	
+
     //calculate averages
     x_avg = average(x_vals, number);
-    y_avg = average(y_vals, number); 
+    y_avg = average(y_vals, number);
 
     for (int i = 0; i < number; i++) {
-        numerator[i] = ((x_vals[i] - x_avg) * (y_vals[i] - y_avg));	// (x_i - x_avg) * (y_i - y_avg)
-        denominator[i] = ((x_vals[i] - x_avg) * (x_vals[i] - x_avg));	// (x_i - x_avg) ^ 2
+        numerator[i] = ((x_vals[i] - x_avg) * (y_vals[i] - y_avg));    // (x_i - x_avg) * (y_i - y_avg)
+        denominator[i] = ((x_vals[i] - x_avg) * (x_vals[i] - x_avg));  // (x_i - x_avg) ^ 2
     }
-    slope = (sum(numerator, number) / sum(denominator, number)); 
+    slope = (sum(numerator, number) / sum(denominator, number));
 
     return slope;
 }

--- a/lowcar/devices/KoalaBear/PID.h
+++ b/lowcar/devices/KoalaBear/PID.h
@@ -34,7 +34,7 @@ class PID {
     float *prev_error, *prev_time;
 
     // ************************** HELPER FUNCTIONS ************************** //
-    
+
     /**
      * Finds the sum of the first i elements of the provided array
      * Arguments:
@@ -44,7 +44,7 @@ class PID {
      *    nums[0] + nums[1] + ... + nums[i - 1]
      */
     float sum(float nums[], int i);
-    
+
     /**
      * Finds the average of the first i elements of the provided array
      * Arguments:
@@ -54,7 +54,7 @@ class PID {
      *    (nums[0] + nums[1] + ... + nums[i - 1]) / i
      */
     float average(float nums[], int i);
-    
+
     /**
      * Computes the linear least squares regression of the points
      * given by x_vals and y_vals, where the x_vals array contains
@@ -68,7 +68,7 @@ class PID {
      * Returns:
      *    Slope of regression line through the given points
      */
-    float regression (float x_vals[], float y_vals[], int number);
+    float regression(float x_vals[], float y_vals[], int number);
 
     /**
      * Converts speed (in duty cycle units from -1.0 to 1.0) to

--- a/lowcar/devices/KoalaBear/PID.h
+++ b/lowcar/devices/KoalaBear/PID.h
@@ -28,12 +28,19 @@ class PID {
 
   private:
     float kp, ki, kd;
-    float prev_error, prev_pos, prev_desired_pos;
+    float prev_pos, prev_desired_pos;
     float velocity;
     float integral;
-    unsigned long prev_time;
+    float *prev_error;
+    unsigned long *prev_time;
 
     // ************************** HELPER FUNCTIONS ************************** //
+    
+    float sum(float nums[], int i);
+    
+    float average(float nums[], int i);
+    
+    float regression (unsigned long x_vals[], float y_vals[], int number);
 
     /**
      * Converts speed (in duty cycle units from -1.0 to 1.0) to

--- a/lowcar/devices/KoalaBear/PID.h
+++ b/lowcar/devices/KoalaBear/PID.h
@@ -31,16 +31,44 @@ class PID {
     float prev_pos, prev_desired_pos;
     float velocity;
     float integral;
-    float *prev_error;
-    unsigned long *prev_time;
+    float *prev_error, *prev_time;
 
     // ************************** HELPER FUNCTIONS ************************** //
     
+    /**
+     * Finds the sum of the first i elements of the provided array
+     * Arguments:
+     *    nums: Array of elements to be summed
+     *    i: Number of elements of nums to sum
+     * Returns:
+     *    nums[0] + nums[1] + ... + nums[i - 1]
+     */
     float sum(float nums[], int i);
     
+    /**
+     * Finds the average of the first i elements of the provided array
+     * Arguments:
+     *    nums: Array of elements to be averaged
+     *    i: Number of elements of nums to use in computing average
+     * Returns:
+     *    (nums[0] + nums[1] + ... + nums[i - 1]) / i
+     */
     float average(float nums[], int i);
     
-    float regression (unsigned long x_vals[], float y_vals[], int number);
+    /**
+     * Computes the linear least squares regression of the points
+     * given by x_vals and y_vals, where the x_vals array contains
+     * the x values of the points to use and y_vals array contains
+     * the y values of the points to use. The number of points to use
+     * is given by the number argument.
+     * Arguments:
+     *    x_vals: Array of x values of the points to calculate regression through
+     *    y_vals: Array of y values of the points to calculate regression through
+     *    number: Number of points to use in calculating regression
+     * Returns:
+     *    Slope of regression line through the given points
+     */
+    float regression (float x_vals[], float y_vals[], int number);
 
     /**
      * Converts speed (in duty cycle units from -1.0 to 1.0) to


### PR DESCRIPTION
Provides for additional adjustability and fine-tuning of the performance of KoalaBears. Several features are added:
- An acceleration constant, which allows us to control how fast a robot can get up to speed (which also dictates how much "inertia" the robot has when slowing down)
- A more accurate calculation of the derivative term of the PID control loop, using a linear regression of a few of the most recent samples of the motor state
- A more thorough attempt at tuning the PID controller coefficients that were determined empirically without tools on staff curry and with the motors free-spinning (in an attempt to make the coefficients usable in many situations)

This also includes a few bug fixes in lowcar:
- Fixed "jumping" when first plugging in the KoalaBear by adding in the variable `online` as a member of the `KoalaBear` class
- Fixed race conditions caused by writing to `enc_a` and `enc_b` while the motors are moving by detaching the interrupts while writing, and then reattaching again once it is done writing
- Fixed `lowcar_print_float` so that it prints negative numbers correctly (it used to print something like `-1.5` as `-1.-500`)

Todos:
- Ensure that the PID coefficients work on not just my KoalaBear
- Ensure that the PID coefficients work on more than just staff curry and free-spinning wheels
- Write a Wiki page explaining PID control and what some of the math does