### PR TITLE
[NET_HANDLER][DEV_HANDLER][CLI] Add CLI attaching

### DIFF
--- a/runtime_util/runtime_util.h
+++ b/runtime_util/runtime_util.h
@@ -7,6 +7,7 @@
 #include <fcntl.h>       // for file opening constants (O_CREAT, O_RDONLY, O_RDWR, etc.)
 #include <pthread.h>     // for thread-functions: pthread_create, pthread_cancel, pthread_join, etc.
 #include <signal.h>      // for setting signal function (setting signal handler)
+#include <stdbool.h>     // for standard boolean types
 #include <stdint.h>      // for uint32_t, int16_t, uint8_t, etc.
 #include <stdio.h>       // for printf, perror, fprintf, fopen, etc.
 #include <stdlib.h>      // for malloc, free
@@ -16,12 +17,6 @@
 #include <sys/time.h>    // for time-related structures and time functions
 #include <sys/un.h>      // for struct sockaddr_un
 #include <unistd.h>      // for F_OK, R_OK, SEEK_SET, SEEK_END, access, ftruncate, read, write, etc.
-
-// Define booleans for convenience
-typedef enum {
-    false,
-    true
-} bool;
 
 // ***************************** DEFINED CONSTANTS ************************** //
 

--- a/runtime_util/runtime_util.h
+++ b/runtime_util/runtime_util.h
@@ -17,6 +17,12 @@
 #include <sys/un.h>      // for struct sockaddr_un
 #include <unistd.h>      // for F_OK, R_OK, SEEK_SET, SEEK_END, access, ftruncate, read, write, etc.
 
+// Define booleans for convenience
+typedef enum {
+    false,
+    true
+} bool;
+
 // ***************************** DEFINED CONSTANTS ************************** //
 
 #define MAX_DEVICES 32  // Maximum number of connected devices

--- a/tests/cli/dev_handler_cli.c
+++ b/tests/cli/dev_handler_cli.c
@@ -25,13 +25,17 @@ void display_help() {
     printf("\tlist          list all currently connected devices and their ports\n");
 }
 
+// True iff this CLI should attach to an already existing instance of dev handler rather than spawning a new one.
+int attach = 0;
 
 // ********************************** COMMAND-SPECIFIC FUNCTIONS  ****************************** //
 
 void clean_up() {
     printf("Exiting Dev Handler CLI...\n");
     disconnect_all_devices();
-    stop_dev_handler();
+    if (!attach) {
+        stop_dev_handler();
+    }
     printf("Done!\n");
     exit(0);
 }
@@ -121,10 +125,21 @@ void prompt_device_disconnect() {
 
 // ********************************** MAIN PROCESS ****************************************** //
 
-int main() {
+int main(int argc, char** argv) {
     // setup
     signal(SIGINT, clean_up);
     int stop = 1;
+
+    // If the argument "attach" is specified, then set the global variable
+    if (argc == 2 && strcmp(argv[1], "attach") == 0) {
+        attach = 1;
+    }
+
+    // Start dev handler if we aren't attaching to existing dev handler
+    if (!attach) {
+        start_dev_handler();
+        sleep(1);  // Allow dev handler to initialize
+    }
 
     // start dev handler
     printf("Starting Dev Handler CLI in the cloudddd...\n");
@@ -132,7 +147,6 @@ int main() {
     display_help();
     printf("Please enter device handler command:\n");
     fflush(stdout);
-    start_dev_handler();
 
     // main loop
     while (stop) {

--- a/tests/cli/dev_handler_cli.c
+++ b/tests/cli/dev_handler_cli.c
@@ -26,7 +26,7 @@ void display_help() {
 }
 
 // True iff this CLI should attach to an already existing instance of dev handler rather than spawning a new one.
-int attach = 0;
+bool attach = 0;
 
 // ********************************** COMMAND-SPECIFIC FUNCTIONS  ****************************** //
 
@@ -46,7 +46,7 @@ void remove_newline(char* nextcmd) {
 }
 
 void prompt_device_connect() {
-    while (1) {
+    while (true) {
         // prints out list of available test devices
         printf("This is the list of devices by name. Type in number on left to use device\n");
         for (int i = 0; i < NUMBER_OF_TEST_DEVICES; i++) {
@@ -90,7 +90,7 @@ void prompt_device_connect() {
 }
 
 void prompt_device_disconnect() {
-    while (1) {
+    while (true) {
         // list the connected virtual devices
         list_devices();
 
@@ -128,11 +128,11 @@ void prompt_device_disconnect() {
 int main(int argc, char** argv) {
     // setup
     signal(SIGINT, clean_up);
-    int stop = 1;
+    bool stop = 1;
 
     // If the argument "attach" is specified, then set the global variable
     if (argc == 2 && strcmp(argv[1], "attach") == 0) {
-        attach = 1;
+        attach = true;
     }
 
     // Start dev handler if we aren't attaching to existing dev handler

--- a/tests/cli/net_handler_cli.c
+++ b/tests/cli/net_handler_cli.c
@@ -15,9 +15,9 @@
  * If no flags are specified, both (fake) Dawn and (fake) Shepherd will be connected to a new
  * net handler instance.
  */
-int spawned_net_handler = 1;  // Whether the CLI spawned a new net handler instance
-int dawn = 0;                 // Whether to connect a fake Dawn
-int shepherd = 0;             // Whether to connect a fake Shepherd
+bool spawned_net_handler = true;  // Whether the CLI spawned a new net handler instance
+bool dawn = false;                // Whether to connect a fake Dawn
+bool shepherd = false;            // Whether to connect a fake Shepherd
 
 // ********************************** COMMAND-SPECIFIC FUNCTIONS  ****************************** //
 
@@ -25,9 +25,9 @@ void prompt_run_mode() {
     robot_desc_field_t client = SHEPHERD;
     robot_desc_val_t mode = IDLE;
     char nextcmd[MAX_CMD_LEN];
-    int keyboard_enabled = 0;  // notify users when keyboard control is enabled/disabled
+    bool keyboard_enabled = false;  // notify users when keyboard control is enabled/disabled
     // get client to send as
-    while (1) {
+    while (true) {
         printf("Send as DAWN or SHEPHERD: ");
         fgets(nextcmd, MAX_CMD_LEN, stdin);
         if (strcmp(nextcmd, "dawn\n") == 0) {
@@ -44,20 +44,20 @@ void prompt_run_mode() {
     }
 
     // get mode to send
-    while (1) {
+    while (true) {
         printf("Send mode IDLE, AUTO, or TELEOP: ");
         fgets(nextcmd, MAX_CMD_LEN, stdin);
         if (strcmp(nextcmd, "idle\n") == 0) {
             mode = IDLE;
-            keyboard_enabled = 0;
+            keyboard_enabled = false;
             break;
         } else if (strcmp(nextcmd, "auto\n") == 0) {
             mode = AUTO;
-            keyboard_enabled = 0;
+            keyboard_enabled = false;
             break;
         } else if (strcmp(nextcmd, "teleop\n") == 0) {
             mode = TELEOP;
-            keyboard_enabled = 1;
+            keyboard_enabled = true;
             break;
         } else if (strcmp(nextcmd, "abort\n") == 0) {
             return;
@@ -78,7 +78,7 @@ void prompt_game_state() {
     robot_desc_field_t state;
     char nextcmd[MAX_CMD_LEN];
     //get state to send
-    while (1) {
+    while (true) {
         printf("Send state POISON_IVY, DEHYDRATION, HYPOTHERMIA: ");
         fgets(nextcmd, MAX_CMD_LEN, stdin);
         if (strcmp(nextcmd, "poison ivy\n") == 0) {
@@ -106,7 +106,7 @@ void prompt_start_pos() {
     char nextcmd[MAX_CMD_LEN];
 
     // get client to send as
-    while (1) {
+    while (true) {
         printf("Send as DAWN or SHEPHERD: ");
         fgets(nextcmd, MAX_CMD_LEN, stdin);
         if (strcmp(nextcmd, "dawn\n") == 0) {
@@ -123,7 +123,7 @@ void prompt_start_pos() {
     }
 
     // get pos to send
-    while (1) {
+    while (true) {
         printf("Send pos LEFT or RIGHT: ");
         fgets(nextcmd, MAX_CMD_LEN, stdin);
         if (strcmp(nextcmd, "left\n") == 0) {
@@ -155,7 +155,7 @@ void prompt_challenge_data() {
     }
 
     // get client to send as
-    while (1) {
+    while (true) {
         printf("Send as DAWN or SHEPHERD: ");
         fgets(nextcmd, MAX_CMD_LEN, stdin);
         if (strcmp(nextcmd, "dawn\n") == 0) {
@@ -224,9 +224,9 @@ void prompt_device_data() {
     }
 
     // enter prompt loop
-    while (1) {
+    while (true) {
         // ask for UID
-        while (1) {
+        while (true) {
             printf("Enter the UID of the device, in base 10: ");
             fgets(nextcmd, MAX_CMD_LEN, stdin);
 
@@ -251,7 +251,7 @@ void prompt_device_data() {
                 printf("\t%4d %s\n", i, dev_names[i]);
             }
         }
-        while (1) {
+        while (true) {
             printf("Enter the device type: ");
             fgets(nextcmd, MAX_CMD_LEN, stdin);
             if (strcmp(nextcmd, "abort\n") == 0) {
@@ -362,7 +362,7 @@ void connect_keyboard() {
 
 int main(int argc, char** argv) {
     char nextcmd[MAX_CMD_LEN];  // to hold nextline
-    int stop = 0;
+    bool stop = false;
 
     signal(SIGINT, sigint_handler);
 
@@ -372,12 +372,12 @@ int main(int argc, char** argv) {
     while ((c = getopt(argc, argv, "ds")) != -1) {
         switch (c) {
             case 'd':
-                spawned_net_handler = 0;
-                dawn = 1;
+                spawned_net_handler = false;
+                dawn = true;
                 break;
             case 's':
-                spawned_net_handler = 0;
-                shepherd = 1;
+                spawned_net_handler = false;
+                shepherd = true;
                 break;
             case '?':
                 fprintf(stderr, "Unknown option `-%c'.\n", optopt);
@@ -393,8 +393,8 @@ int main(int argc, char** argv) {
     // Handle behavior based on flags
     if (spawned_net_handler) {
         // Since we spawn a new net handler, we should also connect a fake Dawn and fake Shepherd
-        dawn = 1;
-        shepherd = 1;
+        dawn = true;
+        shepherd = true;
         // start the net handler and connect all of its output locations to file descriptors in this process
         start_net_handler();
     } else {  // In "attach-only" mode
@@ -414,7 +414,7 @@ int main(int argc, char** argv) {
 
         // compare input string against the available commands
         if (strcmp(nextcmd, "exit\n") == 0) {
-            stop = 1;
+            stop = true;
         } else if (strcmp(nextcmd, "reroute output\n") == 0) {
             prompt_reroute_output();
         } else if (strcmp(nextcmd, "run mode\n") == 0) {

--- a/tests/client/dev_handler_client.c
+++ b/tests/client/dev_handler_client.c
@@ -122,7 +122,7 @@ void start_dev_handler() {
             printf("chdir: %s\n", strerror(errno));
         }
         // execute the device handler process
-        if (execlp("./dev_handler", "dev_handler", "virtual", (char*) 0) < 0) {
+        if (execlp("./dev_handler", "dev_handler", (char*) 0) < 0) {
             printf("execlp: %s\n", strerror(errno));
         }
     }

--- a/tests/client/dev_handler_client.h
+++ b/tests/client/dev_handler_client.h
@@ -3,6 +3,7 @@
 
 #include <errno.h>       // for errno
 #include <signal.h>      // for SIGINT (Ctrl+C)
+#include <stdbool.h>     // for boolean types
 #include <stdint.h>      // for int with specific widths
 #include <stdio.h>       // for printf()
 #include <stdlib.h>      // for exit()

--- a/tests/client/net_handler_client.c
+++ b/tests/client/net_handler_client.c
@@ -5,8 +5,8 @@ pid_t nh_pid;                           // holds the pid of the net_handler proc
 struct sockaddr_in udp_servaddr = {0};  // holds the udp server address
 pthread_t dump_tid;                     // holds the thread id of the output dumper threads
 pthread_mutex_t print_udp_mutex;        // lock over whether to print the next received udp
-int print_next_udp;                     // 0 if we want to suppress incoming dev data, 1 to print incoming dev data to stdout
-int hypothermia_enabled = 0;            // 0 if hypothermia enabled, 1 if disabled
+bool print_next_udp;                    // false if we want to suppress incoming dev data, true to print incoming dev data to stdout
+bool hypothermia_enabled = false;
 
 int nh_tcp_shep_fd = -1;      // holds file descriptor for TCP Shepherd socket
 int nh_tcp_dawn_fd = -1;      // holds file descriptor for TCP Dawn socket
@@ -132,7 +132,7 @@ static void recv_udp_data(int udp_fd) {
     // if we were asked to print the last UDP message, set output back to /dev/null
     pthread_mutex_lock(&print_udp_mutex);
     if (print_next_udp) {
-        print_next_udp = 0;
+        print_next_udp = false;
         udp_output_fp = null_fp;
     }
     pthread_mutex_unlock(&print_udp_mutex);
@@ -208,7 +208,7 @@ static void* output_dump(void* args) {
     maxfd++;
 
     // wait for net handler to create some output, then print that output to stdout of this process
-    while (1) {
+    while (true) {
         // set up the read_set argument to selct()
         FD_ZERO(&read_set);
         FD_SET(nh_tcp_shep_fd, &read_set);
@@ -268,7 +268,7 @@ static void* output_dump(void* args) {
 
 // ************************************* NET HANDLER CLIENT FUNCTIONS ************************** //
 
-void connect_clients(int dawn, int shepherd) {
+void connect_clients(bool dawn, bool shepherd) {
     // Connect Dawn and Shepherd to net handler over TCP
     nh_tcp_dawn_fd = (dawn) ? connect_tcp(DAWN) : -1;
     nh_tcp_shep_fd = (shepherd) ? connect_tcp(SHEPHERD) : -1;
@@ -290,7 +290,7 @@ void connect_clients(int dawn, int shepherd) {
     if (pthread_mutex_init(&print_udp_mutex, NULL) != 0) {
         printf("pthread_mutex_init: print udp mutex\n");
     }
-    print_next_udp = 0;
+    print_next_udp = false;
     udp_output_fp = null_fp;  // by default set to output to /dev/null
 
     // start the thread that is dumping output from net_handler to stdout of this process
@@ -405,11 +405,11 @@ void send_game_state(robot_desc_field_t state) {
         case (HYPOTHERMIA):
             if (hypothermia_enabled) {
                 game_state.state = STATE__HYPOTHERMIA_END;
-                hypothermia_enabled = 0;
+                hypothermia_enabled = false;
                 break;
             } else {
                 game_state.state = STATE__HYPOTHERMIA_START;
-                hypothermia_enabled = 1;
+                hypothermia_enabled = true;
                 break;
             }
         default:
@@ -608,7 +608,7 @@ void send_device_subs(dev_subs_t* subs, int num_devices) {
 
 void print_next_dev_data() {
     pthread_mutex_lock(&print_udp_mutex);
-    print_next_udp = 1;
+    print_next_udp = true;
     udp_output_fp = stdout;
     pthread_mutex_unlock(&print_udp_mutex);
     usleep(400000);  // allow time for output_dump to react and generate output before returning to client

--- a/tests/client/net_handler_client.h
+++ b/tests/client/net_handler_client.h
@@ -11,7 +11,15 @@ typedef struct {
 } dev_subs_t;
 
 /**
- * Starts the real net handler process and connects to all of its outputs
+ * Connects clients to an already existing instance of runtime.
+ * Arguments:
+ *    dawn: Whether to connect a fake Dawn
+ *    shepherd: Whether to connect a fake Shepherd
+ */
+void connect_clients(int dawn, int shepherd);
+
+/**
+ * Starts a new instance of net handler and connects a fake Dawn and fake Shepherd.
  * Sets everything up for querying from the CLI or from a test.
  */
 void start_net_handler();

--- a/tests/client/net_handler_client.h
+++ b/tests/client/net_handler_client.h
@@ -1,6 +1,7 @@
 #ifndef NET_CLIENT_H
 #define NET_CLIENT_H
 
+#include <stdbool.h>
 #include <sys/wait.h>
 #include "../../net_handler/net_util.h"
 
@@ -16,7 +17,7 @@ typedef struct {
  *    dawn: Whether to connect a fake Dawn
  *    shepherd: Whether to connect a fake Shepherd
  */
-void connect_clients(int dawn, int shepherd);
+void connect_clients(bool dawn, bool shepherd);
 
 /**
  * Starts a new instance of net handler and connects a fake Dawn and fake Shepherd.


### PR DESCRIPTION
Net handler CLI and dev handler CLI can now "attach" to their respective existing instances of runtime instead of spawning a new instance.
- Net handler CLI can specify zero or more flags from (`-d` and `-s`)
  - Without arguments it spawns a new net handler instance and connects a fake Dawn and fake Shepherd.
    - This is unchanged and the same behavior as on `master`.
  - `-d` : Does not spawn a new net handler; Connects a fake Dawn
  - `-s` : Does not spawn a new net handler; Connects a fake Shepherd
- Dev handler no longer takes in arguments.
  - Dev handler now detects BOTH Arduinos and virtual devices.
 - Dev handler CLI has an optional argument `attach`.
   - Without this argument, it spawns a new dev handler. This is unchanged and the same behavior as on `master`.
   - With this argument, it **doesn't** spawn a new dev handler. Disconnecting/connecting virtual devices will work normally with an existing instance of dev handler.

Attempting to use these CLIs in their respective "attach" modes without a preexisting instance of runtime is will have undefined behavior.

Closes #118 