### PR TITLE
[MISC] Implement ngrok restarting from webpage

### DIFF
--- a/systemd/ngrok.sh
+++ b/systemd/ngrok.sh
@@ -2,14 +2,8 @@
 
 function sigint_handler {
     pkill -u pi /home/pi/ngrok
-    pkill -u pi ngrok_displayer
 }
 
 trap 'sigint_handler' INT
 
-nohup /home/pi/ngrok start --all --config /home/pi/runtime/systemd/ngrok.yml > /dev/null &
-
-sleep 5
-
-python3 ngrok_displayer.py > /dev/null
-
+nohup /home/pi/ngrok start --all --config /home/pi/runtime/systemd/ngrok.yml > /dev/null

--- a/systemd/ngrok_displayer.py
+++ b/systemd/ngrok_displayer.py
@@ -2,6 +2,7 @@
 
 """
 This script is based on this https://gist.github.com/davidbgk/b10113c3779b8388e96e6d0c44e03a74
+and https://gist.github.com/bradmontgomery/2219997
 The ngrok process that is started by Runtime when it boots up also starts a server on localhost
 which broadcasts useful information about the tunnels that was created locally.
 This script simply requests the names of the tunnels and their IP addresses and posts them as a
@@ -9,6 +10,7 @@ bare-minimum web page on the local network so that somebody who is on the local 
 Raspberry Pi is connected to can view the names and IP addresses of the ngrok tunnels on the 
 Raspberry Pi without being ssh'ed into the machine. 
 The webpage will be at 192.168.0.1xx:8000 if connected to Motherbase in 101.
+Accessing 192.168.0.1xx:8000/new will generate a new ngrok session before displayin the addresses.
 """
 
 import requests
@@ -17,41 +19,97 @@ import http.server
 import socketserver
 import time
 from http import HTTPStatus
+import os
 
-recv_data = False
+PORT = 8000 # The port at which the webpage is hosted at on localhost
 tcpSubstring = "tcp://"
 
-while recv_data == False:
-    print(recv_data)
+# The ngrok IP addresses
+publicTCPUrl = ""
+publicUDPUrl = ""
+publicSSHUrl = ""
+
+def update_IP_addresses():
+    """
+    Updates the global variables containing the IP addresses.
+    """
+    global publicTCPUrl
+    global publicUDPUrl
+    global publicSSHUrl
+    while True:
+        try:
+            requestedTcpUrl = 'http://localhost:4040/api/tunnels/tcp' # url for the comms tunnel used for regular tcp data connection with dawn
+            reqTCP = requests.get(url=requestedTcpUrl)
+            parsedTCPRequest = reqTCP.json()
+            publicTCPUrl = 'IP Address: ' + parsedTCPRequest["public_url"].replace(tcpSubstring, '') + '\n'
+
+            requestedUdpUrl = 'http://localhost:4040/api/tunnels/converted_udp' # url for the comms tunnel used for udp forwarding
+            reqUDP = requests.get(url=requestedUdpUrl)
+            parsedUDPRequest = reqUDP.json()
+            publicUDPUrl = 'UDP Tunneling: ' + parsedUDPRequest["public_url"].replace(tcpSubstring, '') + '\n'
+
+            requestedSshUrl = 'http://localhost:4040/api/tunnels/ssh' # url for the comms tunnel used for ssh
+            reqSSH = requests.get(url=requestedSshUrl)
+            parsedSSHRequest = reqSSH.json()
+            publicSSHUrl = 'SSH Tunneling: ' + parsedSSHRequest["public_url"].replace(tcpSubstring, '') + '\n'
+
+            break
+        except KeyError:
+            time.sleep(1)
+            continue
+
+# Declare the HTTP request handler when we access the webpage
+class Handler(http.server.SimpleHTTPRequestHandler):
+    # Helper function that indicates the webpage access is OK and an HTML document will be served
+    def _set_headers(self):
+        self.send_response(200)
+        self.send_header("Content-type", "text/html")
+        self.end_headers()
+
+    def _html(self):
+        """
+        Returns an HTML page with the ngrok IP addresses
+        """
+        content = f"""
+        <html>
+            <body>
+                <h1>Runtime ngrok IP Addresses</h1>
+                <p>
+                    <b>
+                        Put these IP addresses into Dawn to connect to the robot!<br>
+                        Refresh this page for the most up-to-date addresses.<br>
+                        Add "/new" after {PORT} to generate a new session.
+                    </b>
+                    <br>
+                    <br>
+                    {publicTCPUrl}<br>
+                    {publicUDPUrl}<br>
+                    {publicSSHUrl}
+                </p>
+            </body>
+        </html>
+        """
+        return content.encode("utf8")
+
+    def do_GET(self):
+        """
+        A GET request will display the IP addresses in an HTML page.
+        If the path "/new" is supplied, ngrok will restart first.
+        """
+        self._set_headers()
+        if self.path == "/new": # Restart ngrok
+            self.wfile.write(str.encode("Generating a new session..."))
+            os.system("sudo systemctl restart ngrok.service")
+            time.sleep(5) # Wait for ngrok to properly restart
+        update_IP_addresses()
+        self.wfile.write(self._html())
+
+# Serve the HTTP webpage
+while True:
     try:
-        requestedTcpUrl = 'http://localhost:4040/api/tunnels/tcp' # url for the comms tunnel used for regular tcp data connection with dawn
-        reqTCP = requests.get(url=requestedTcpUrl)
-        parsedTCPRequest = reqTCP.json()
-        print(parsedTCPRequest)
-        publicTCPUrl = 'IP Address: ' + parsedTCPRequest["public_url"].replace(tcpSubstring, '') + '\n'
-
-        requestedUdpUrl = 'http://localhost:4040/api/tunnels/converted_udp' # url for the comms tunnel used for udp forwarding
-        reqUDP = requests.get(url=requestedUdpUrl)
-        parsedUDPRequest = reqUDP.json()
-        publicUDPUrl = 'UDP Tunneling: ' +parsedUDPRequest["public_url"].replace(tcpSubstring, '') + '\n'
-
-        requestedSshUrl = 'http://localhost:4040/api/tunnels/ssh' # url for the comms tunnel used for ssh
-        reqSSH = requests.get(url=requestedSshUrl)
-        parsedSSHRequest = reqSSH.json()
-        publicSSHUrl = 'SSH Tunneling: ' + parsedSSHRequest["public_url"].replace(tcpSubstring, '') + '\n'
-        recv_data = True
-    except KeyError:
+        httpd = socketserver.TCPServer(('', PORT), Handler)
+        break
+    except OSError: # Sometimes we get an "Address already in use" error. Just try again.
         time.sleep(1)
         continue
-
-class Handler(http.server.SimpleHTTPRequestHandler):
-    def do_GET(self):
-        self.send_response(HTTPStatus.OK)
-        self.end_headers()
-        self.wfile.write(str.encode(publicTCPUrl))
-        self.wfile.write(str.encode(publicUDPUrl))
-        self.wfile.write(str.encode(publicSSHUrl))
-
-
-httpd = socketserver.TCPServer(('', 8000), Handler)
 httpd.serve_forever()

--- a/systemd/ngrok_displayer.service
+++ b/systemd/ngrok_displayer.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Serves a webpage that displays the ngrok tunnel IP addresses.
+
+[Service]
+Type=simple
+User=pi
+WorkingDirectory=/home/pi/runtime/systemd/
+ExecStart=python3 ngrok_displayer.py
+ExecReload=/bin/kill -SIGINT $MAINPID
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
- `ngrok_displayer` is its own service.
- Accessing `/new` endpoint will restart `ngrok.service` first.
- Refreshing webpage will fetch the current IP addresses before
  displaying anything.

Resolves #197