### PR TITLE
[LOWCAR] Several lowcar fixes

### DIFF
--- a/dev_handler/message.c
+++ b/dev_handler/message.c
@@ -195,7 +195,7 @@ message_t* make_ping() {
         log_printf(FATAL, "make_ping: Failed to malloc");
         exit(1);
     }
-    ping->message_id = PING;
+    ping->message_id = DEVICE_PING;
     ping->payload = NULL;
     ping->payload_length = 0;
     ping->max_payload_length = 0;

--- a/dev_handler/message.h
+++ b/dev_handler/message.h
@@ -13,11 +13,11 @@
 #include "../logger/logger.h"
 #include "../runtime_util/runtime_util.h"
 
-/* The maximum number of milliseconds to wait between each PING from a device
+/* The maximum number of milliseconds to wait between each DEVICE_PING from a device
  * Waiting for this long will exit all threads for that device (doing cleanup as necessary) */
 #define TIMEOUT 1000
 
-// The number of milliseconds between each PING sent to the device
+// The number of milliseconds between each DEVICE_PING sent to the device
 #define PING_FREQ 250
 
 // The size in bytes of the message delimiter
@@ -42,7 +42,7 @@
 // The types of messages
 typedef enum {
     NOP = 0x00,                   // Dummy message
-    PING = 0x01,                  // To lowcar
+    DEVICE_PING = 0x01,           // To lowcar
     ACKNOWLEDGEMENT = 0x02,       // To dev handler
     SUBSCRIPTION_REQUEST = 0x03,  // To lowcar
     DEVICE_WRITE = 0x04,          // To lowcar
@@ -82,9 +82,9 @@ void print_bytes(uint8_t* data, size_t len);
 message_t* make_empty(ssize_t payload_size);
 
 /**
- * Builds a PING message
+ * Builds a DEVICE_PING message
  * Returns:
- *    A message of type PING
+ *    A message of type DEVICE_PING
  *      payload_length 0
  *      max_payload_length 0
  */

--- a/lowcar/devices/Device/Device.cpp
+++ b/lowcar/devices/Device/Device.cpp
@@ -31,7 +31,7 @@ void Device::loop() {
 
     if (sts == Status::SUCCESS) {  // we have a message!
         switch (this->curr_msg.message_id) {
-            case MessageID::PING:
+            case MessageID::DEVICE_PING:
                 this->last_received_ping_time = this->curr_time;
                 // If this is the first PING received, send an ACKNOWLEDGEMENT
                 if (!this->enabled) {

--- a/lowcar/devices/Device/Device.cpp
+++ b/lowcar/devices/Device/Device.cpp
@@ -12,12 +12,10 @@ Device::Device(DeviceType dev_id, uint8_t dev_year, uint32_t timeout) {
     this->params = 0;         // Initialize to no subscribed parameters (empty DEVICE_DATA)
     this->sub_interval = 0;   // 0 acts as flag indicating no subscription
     this->timeout = timeout;  // timeout in ms how long we tolerate not receiving a PING from dev handler
-    this->enabled = FALSE;
+    this->enabled = FALSE;    // Whether or not the device currently has a connection with Runtime
 
     this->msngr = new Messenger();
     this->led = new StatusLED();
-
-    device_enable();  // call device's enable function
 
     this->last_sent_data_time = this->last_received_ping_time = this->curr_time = millis();
 }
@@ -37,9 +35,10 @@ void Device::loop() {
                 this->last_received_ping_time = this->curr_time;
                 // If this is the first PING received, send an ACKNOWLEDGEMENT
                 if (!this->enabled) {
-                    this->msngr->lowcar_printf("Device type %d with UID ending in %X contacted; sending ACK", (uint8_t) this->dev_id.type, this->dev_id.uid);
                     this->msngr->send_message(MessageID::ACKNOWLEDGEMENT, &(this->curr_msg), &(this->dev_id));
+                    this->msngr->lowcar_printf("Device type %d with UID ending in %X contacted; sent ACK", (uint8_t) this->dev_id.type, this->dev_id.uid);
                     this->enabled = TRUE;
+                    device_enable();
                 }
                 break;
 

--- a/lowcar/devices/Device/Device.cpp
+++ b/lowcar/devices/Device/Device.cpp
@@ -37,7 +37,7 @@ void Device::loop() {
                 this->last_received_ping_time = this->curr_time;
                 // If this is the first PING received, send an ACKNOWLEDGEMENT
                 if (!this->enabled) {
-                    this->msngr->lowcar_printf("Device type %d with UID ending in %X contacted; sending ACK", this->dev_id.type, this->dev_id.uid);
+                    this->msngr->lowcar_printf("Device type %d with UID ending in %X contacted; sending ACK", (uint8_t) this->dev_id.type, this->dev_id.uid);
                     this->msngr->send_message(MessageID::ACKNOWLEDGEMENT, &(this->curr_msg), &(this->dev_id));
                     this->enabled = TRUE;
                 }

--- a/lowcar/devices/Device/Device.cpp
+++ b/lowcar/devices/Device/Device.cpp
@@ -11,7 +11,7 @@ Device::Device(DeviceType dev_id, uint8_t dev_year, uint32_t timeout) {
 
     this->params = 0;         // Initialize to no subscribed parameters (empty DEVICE_DATA)
     this->sub_interval = 0;   // 0 acts as flag indicating no subscription
-    this->timeout = timeout;  // timeout in ms how long we tolerate not receiving a PING from dev handler
+    this->timeout = timeout;  // timeout in ms how long we tolerate not receiving a DEVICE_PING from dev handler
     this->enabled = FALSE;    // Whether or not the device currently has a connection with Runtime
 
     this->msngr = new Messenger();
@@ -33,7 +33,7 @@ void Device::loop() {
         switch (this->curr_msg.message_id) {
             case MessageID::DEVICE_PING:
                 this->last_received_ping_time = this->curr_time;
-                // If this is the first PING received, send an ACKNOWLEDGEMENT
+                // If this is the first DEVICE_PING received, send an ACKNOWLEDGEMENT
                 if (!this->enabled) {
                     this->msngr->send_message(MessageID::ACKNOWLEDGEMENT, &(this->curr_msg), &(this->dev_id));
                     this->msngr->lowcar_printf("Device type %d with UID ending in %X contacted; sent ACK", (uint8_t) this->dev_id.type, this->dev_id.uid);
@@ -63,13 +63,13 @@ void Device::loop() {
         this->msngr->lowcar_printf("Error when reading message by lowcar device");
     }
 
-    // If it's been too long since we received a PING, disable the device
+    // If it's been too long since we received a DEVICE_PING, disable the device
     if ((this->timeout > 0) && (this->curr_time - this->last_received_ping_time >= this->timeout)) {
         device_reset();
         this->enabled = FALSE;
     }
 
-    // If we still haven't gotten our first PING yet (or dev handler timed out), keep waiting for a PING
+    // If we still haven't gotten our first DEVICE_PING yet (or dev handler timed out), keep waiting for a DEVICE_PING
     if (!(this->enabled)) {
         return;
     }

--- a/lowcar/devices/Device/Device.h
+++ b/lowcar/devices/Device/Device.h
@@ -95,12 +95,12 @@ class Device {
   protected:
     Messenger* msngr;  // Encodes/decodes and send/receive messages over serial
     uint8_t enabled;
+    StatusLED* led;                    // The LED on the Arduino
 
   private:
     const static float MAX_SUB_INTERVAL_MS;  // Maximum tolerable subscription delay, in ms
     const static float MIN_SUB_INTERVAL_MS;  // Minimum tolerable subscription delay, in ms
 
-    StatusLED* led;                    // The LED on the Arduino
     dev_id_t dev_id;                   // dev_id of this device determined when flashing
     uint32_t params;                   // Bitmap of parameters subscribed to by dev handler
     uint16_t sub_interval;             // Time between sending new DEVICE_DATA messages

--- a/lowcar/devices/Device/Device.h
+++ b/lowcar/devices/Device/Device.h
@@ -95,7 +95,7 @@ class Device {
   protected:
     Messenger* msngr;  // Encodes/decodes and send/receive messages over serial
     uint8_t enabled;
-    StatusLED* led;                    // The LED on the Arduino
+    StatusLED* led;  // The LED on the Arduino
 
   private:
     const static float MAX_SUB_INTERVAL_MS;  // Maximum tolerable subscription delay, in ms

--- a/lowcar/devices/Device/StatusLED.h
+++ b/lowcar/devices/Device/StatusLED.h
@@ -23,7 +23,7 @@ class StatusLED {
 
   private:
     const static int LED_PIN = LED_BUILTIN;  // pin to control the LED
-    bool led_enabled;               // keeps track of whether LED is on or off
+    bool led_enabled;                        // keeps track of whether LED is on or off
 
     // Blinks NUM times, waiting MS ms between the toggles, and SPACE ms between each blink
     void blink(int num, int ms, int space);

--- a/lowcar/devices/Device/StatusLED.h
+++ b/lowcar/devices/Device/StatusLED.h
@@ -22,7 +22,7 @@ class StatusLED {
     void slow_blink(int num);
 
   private:
-    const static int LED_PIN = 17;  // pin to control the LED
+    const static int LED_PIN = LED_BUILTIN;  // pin to control the LED
     bool led_enabled;               // keeps track of whether LED is on or off
 
     // Blinks NUM times, waiting MS ms between the toggles, and SPACE ms between each blink

--- a/lowcar/devices/Device/defs.h
+++ b/lowcar/devices/Device/defs.h
@@ -48,7 +48,7 @@ enum class MessageID : uint8_t {
 };
 
 // identification for device types
-enum class DeviceType : uint16_t {
+enum class DeviceType : uint8_t {
     DUMMY_DEVICE = 0x00,
     LIMIT_SWITCH = 0x01,
     LINE_FOLLOWER = 0x02,

--- a/lowcar/devices/Device/defs.h
+++ b/lowcar/devices/Device/defs.h
@@ -39,7 +39,7 @@ enum class Digital : uint8_t {
 /* The types of messages */
 enum class MessageID : uint8_t {
     NOP = 0x00,                   // Dummy message
-    DEVICE_PING = 0x01,                  // To lowcar
+    DEVICE_PING = 0x01,           // To lowcar
     ACKNOWLEDGEMENT = 0x02,       // To dev handler
     SUBSCRIPTION_REQUEST = 0x03,  // To lowcar
     DEVICE_WRITE = 0x04,          // To lowcar

--- a/lowcar/devices/Device/defs.h
+++ b/lowcar/devices/Device/defs.h
@@ -39,7 +39,7 @@ enum class Digital : uint8_t {
 /* The types of messages */
 enum class MessageID : uint8_t {
     NOP = 0x00,                   // Dummy message
-    PING = 0x01,                  // To lowcar
+    DEVICE_PING = 0x01,                  // To lowcar
     ACKNOWLEDGEMENT = 0x02,       // To dev handler
     SUBSCRIPTION_REQUEST = 0x03,  // To lowcar
     DEVICE_WRITE = 0x04,          // To lowcar

--- a/scripts/flash.sh
+++ b/scripts/flash.sh
@@ -52,8 +52,6 @@ function usage {
         printf "\t$type\n"
     done
     printf "\n"
-    
-    printf "Remember that you need to install arduino-cli first before you can use this flash script!\n\n"
     exit 1
 }
 
@@ -312,18 +310,17 @@ arduino-cli config init
 # update the core index (see arduino-cli documentation)
 arduino-cli core update-index
 
+# symlink libraries
+symlink_libs
+
+# insert uid and requested device into Device_template, copy into Device/Device.ino
+make_device_ino
+
 # get the device port, board, fqbn, and core
 get_board_info
 
 # install this device's core
 arduino-cli core install $DEVICE_CORE
-
-# symlink libraries
-get_lib_install_dir
-symlink_libs
-
-# insert uid and requested device into Device_template, copy into Device/Device.ino
-make_device_ino
 
 # compile the code
 printf "\nCompiling code...\n\n"

--- a/tests/client/virtual_devices/virtual_device_util.c
+++ b/tests/client/virtual_devices/virtual_device_util.c
@@ -168,7 +168,7 @@ void lowcar_protocol(int fd, uint8_t type, uint8_t year, uint64_t uid,
         if (receive_message(fd, incoming_msg) == 0) {
             // Got a message
             switch (incoming_msg->message_id) {
-                case PING:
+                case DEVICE_PING:
                     last_received_ping_time = now;
                     if (!sent_ack) {
                         // Send an ack
@@ -206,14 +206,13 @@ void lowcar_protocol(int fd, uint8_t type, uint8_t year, uint64_t uid,
             continue;
         }
 
-        // Make sure we're receiving PING messages still
+        // Make sure we're receiving DEVICE_PING messages still
         if ((now - last_received_ping_time) >= TIMEOUT) {
             printf("lowcar_protocol: DEV_HANDLER timed out!\n");
             exit(1);
         }
-        // Check if we should send another PING
+        // Check if we should send another DEVICE_PING
         if ((now - last_sent_ping_time) >= PING_FREQ) {
-            // printf("Sending PING\n");
             outgoing_msg = make_ping();
             send_message(fd, outgoing_msg);
             destroy_message(outgoing_msg);
@@ -226,7 +225,6 @@ void lowcar_protocol(int fd, uint8_t type, uint8_t year, uint64_t uid,
         }
         // Check if we should send another DEVICE_DATA
         if (subscribed_params && ((now - last_sent_data_time) >= subscription_interval)) {
-            // printf("Sending DEVICE_DATA with bitmap 0x%08X\n", subscribed_params);
             outgoing_msg = make_device_data(type, subscribed_params, params);
             send_message(fd, outgoing_msg);
             destroy_message(outgoing_msg);


### PR DESCRIPTION
- The Device Type is a 1 byte value. This is already the case in the Runtime code, but it seems like we forgot to change this in the lowcar code.
- "Enabled" in lowcar is clarified to mean "connected to Runtime". In the constructor, `enabled` is false. When `enabled` is set to true (i.e. when the device sends an `ACK`), we call `device_enable()`.