### PR TITLE
[SHM][UI] Add check in shm_init() that shm exists

### DIFF
--- a/shm_wrapper/shm_wrapper.c
+++ b/shm_wrapper/shm_wrapper.c
@@ -202,6 +202,11 @@ static void shm_close() {
 
 // ************************************ PUBLIC WRAPPER FUNCTIONS ****************************************** //
 
+bool shm_exists() {
+    // Assumes all shared memory blocks are created together and destroyed together
+    return (access("/dev/shm/dev-shm", F_OK) == 0);
+}
+
 void generate_sem_name(stream_t stream, int dev_ix, char* name) {
     if (stream == DATA) {
         sprintf(name, "/data_sem_%d", dev_ix);
@@ -223,6 +228,12 @@ int get_dev_ix_from_uid(uint64_t dev_uid) {
 }
 
 void shm_init() {
+    // Verify that shared memory exists
+    if (!shm_exists()) {
+        log_printf(ERROR, "shm_init: SHM does not exist!");
+        exit(1);
+    }
+
     int fd_shm;              // file descriptor of the memory-mapped shared memory
     char sname[SNAME_SIZE];  // for holding semaphore names
 

--- a/shm_wrapper/shm_wrapper.h
+++ b/shm_wrapper/shm_wrapper.h
@@ -3,7 +3,8 @@
 
 #include <limits.h>     // for UCHAR_MAX
 #include <semaphore.h>  // for semaphores
-#include <sys/mman.h>   // for posix shared memory
+#include <stdbool.h>
+#include <sys/mman.h>  // for posix shared memory
 
 #include "../logger/logger.h"              // for logger
 #include "../runtime_util/runtime_util.h"  // for runtime constants
@@ -96,6 +97,9 @@ extern log_data_shm_t* log_data_shm_ptr;  // points to shared memory block for l
 extern sem_t* log_data_sem;               // semaphore used as a mutex on the log data
 
 // ******************************************* WRAPPER FUNCTIONS ****************************************** //
+
+// Returns true iff shared memory exists.
+bool shm_exists();
 
 /**
  * Function that generates a semaphore name for the data and command streams

--- a/tests/cli/shm_ui.c
+++ b/tests/cli/shm_ui.c
@@ -145,11 +145,11 @@ void display_controls() {
 
     // Right
     addch(ACS_RARROW | A_REVERSE);
-    printw(" Next\n");
+    printw(" Next");
 
     attroff(A_BOLD);
 
-    printw("\tUnfocus this terminal to ignore inputs");
+    printw("\tUnfocus this terminal to ignore inputs!");
     refresh();
 }
 
@@ -598,6 +598,14 @@ int main(int argc, char** argv) {
 
     // Update the UI continually (based on refresh rate)
     while (1) {
+        // Verify that shared memory still exists.
+        // This can be helpful to know when shared memory gets unexpectedly destroyed.
+        if (!shm_exists()) {
+            endwin();  // Stop the UI
+            log_printf(ERROR, "SHM was destroyed unexpectedly!");
+            exit(1);
+        }
+
         // Get newest shm data
         get_catalog(&catalog);
         get_device_identifiers(dev_ids);


### PR DESCRIPTION
- UI fails in attach mode if shm doesn't exist.
- UI polls for the existence of shm and will exit if it was destroyed.
- Fix minor visual bug with the note at the bottom of the UI not displaying properly.