### PR TITLE
[EXECUTOR][NET_HANDLER] Changed log level in kill_subprocess()

### DIFF
--- a/executor/executor.c
+++ b/executor/executor.c
@@ -513,7 +513,7 @@ static pid_t start_mode_subprocess(char* student_code, char* challenge_code) {
             robot_desc_write(RUN_MODE, IDLE);  // Will tell parent to call kill_subprocess
         } else {
             executor_init(student_code);
-            signal(SIGTERM, python_exit_handler); // kill subprocess regardless
+            signal(SIGTERM, python_exit_handler);  // kill subprocess regardless
             run_mode(mode);
         }
         exit(0);

--- a/executor/executor.c
+++ b/executor/executor.c
@@ -516,7 +516,7 @@ static pid_t start_mode_subprocess(char* student_code, char* challenge_code) {
             robot_desc_write(RUN_MODE, IDLE);  // Will tell parent to call kill_subprocess
         } else {
             executor_init(student_code);
-            signal(SIGTERM, python_exit_handler);
+            // signal(SIGTERM, python_exit_handler); // kill subprocess regardless
             run_mode(mode);
         }
         exit(0);

--- a/executor/executor.c
+++ b/executor/executor.c
@@ -16,6 +16,8 @@
 #include "../runtime_util/runtime_util.h"  //for runtime constants (TODO: consider removing relative pathname in include)
 #include "../shm_wrapper/shm_wrapper.h"    // Shared memory wrapper to get/send device data
 
+#define DEBUG_SIGNAL 15  // Signal to log as DEBUG instead of ERROR
+
 // Global variables to all functions and threads
 const char* api_module = "studentapi";
 char* module_name;
@@ -482,12 +484,9 @@ static void kill_subprocess() {
     if (waitpid(pid, &status, 0) == -1) {
         log_printf(ERROR, "Wait failed for pid %d: %s", pid, strerror(errno));
     }
-    if (!WIFEXITED(status)) {
-        log_printf(ERROR, "Error when shutting down execution of mode %d", mode);
-    }
-    if (WIFSIGNALED(status)) {
-        log_printf(ERROR, "killed by signal %d\n", WTERMSIG(status));
-    }
+    int sig_number = WTERMSIG(status);
+    log_printf((sig_number == DEBUG_SIGNAL) ? DEBUG : ERROR, "Error when shutting down execution of mode %d", mode);
+    log_printf((sig_number == DEBUG_SIGNAL) ? DEBUG : ERROR, "killed by signal %d\n", sig_number);
     // Reset parameters if robot was in AUTO or TELEOP. Needed for safety
     if (mode != CHALLENGE) {
         reset_params();

--- a/net_handler/net_handler.c
+++ b/net_handler/net_handler.c
@@ -92,7 +92,7 @@ static uint8_t determine_client(int connfd) {
         int num_bytes_read = 0;
         uint8_t client_id = 255;
         num_bytes_read = read(connfd, &client_id, 1);
-        if(num_bytes_read == -1) {
+        if (num_bytes_read == -1) {
             log_printf(ERROR, "determine_client(): Error when reading from connfd, %s", strerror(errno));
             return 253;
         }

--- a/net_handler/net_handler.c
+++ b/net_handler/net_handler.c
@@ -89,8 +89,13 @@ static uint8_t determine_client(int connfd) {
         log_printf(ERROR, "determine_client: Timeout on waiting for client ID"); /* a timeout occured */
         return 254;
     } else { /* there was data to read */
+        int num_bytes_read = 0;
         uint8_t client_id = 255;
-        read(connfd, &client_id, 1);
+        num_bytes_read = read(connfd, &client_id, 1);
+        if(num_bytes_read == -1) {
+            log_printf(ERROR, "determine_client(): Error when reading from connfd, %s", strerror(errno));
+            return 253;
+        }
         return client_id;
     }
 }

--- a/net_handler/net_handler.c
+++ b/net_handler/net_handler.c
@@ -66,6 +66,35 @@ static void sigint_handler(int sig_num) {
     exit(0);
 }
 
+/**
+ * Returns the client ID 
+ * (0 for shepherd, 1 for Dawn, 254 on timeout, 255 on error)
+ */
+static uint8_t determine_client(int connfd) {
+    fd_set set;
+    FD_ZERO(&set);        /* clear the set */
+    FD_SET(connfd, &set); /* add our file descriptor to the set */
+
+    // Set the timeout duration
+    struct timeval timeout;
+    timeout.tv_sec = 1;
+    timeout.tv_usec = 0;
+
+    // Wait for client ID to be received, with timeout enabled
+    int ret = select(connfd + 1, &set, NULL, NULL, &timeout);
+    if (ret == -1) {
+        log_printf(ERROR, "determine_client: Error on select"); /* an error accured */
+        return 255;
+    } else if (ret == 0) {
+        log_printf(ERROR, "determine_client: Timeout on waiting for client ID"); /* a timeout occured */
+        return 254;
+    } else { /* there was data to read */
+        uint8_t client_id = 255;
+        read(connfd, &client_id, 1);
+        return client_id;
+    }
+}
+
 // ******************************************* MAIN ROUTINE ******************************* //
 
 int main() {
@@ -101,17 +130,24 @@ int main() {
         log_printf(DEBUG, "Received connection request from %s:%d", inet_ntoa(cli_addr.sin_addr), ntohs(cli_addr.sin_port));
 
         //get the client ID (first byte on the socket from client)
-        if (read(connfd, &client_id, 1) == -1) {
-            log_printf(ERROR, "Couldn't get client type: %s", strerror(errno));
-            continue;
-        }
+        client_id = determine_client(connfd);
 
         //if the incoming request is shepherd or dawn, start the appropriate threads
-        if (client_id == 0 && cli_addr.sin_family == AF_INET && robot_desc_read(SHEPHERD) == DISCONNECTED) {
-            log_printf(DEBUG, "Starting Shepherd connection");
+        if (client_id == 0 && cli_addr.sin_family == AF_INET) {
+            if (robot_desc_read(SHEPHERD) == DISCONNECTED) {
+                log_printf(DEBUG, "Starting Shepherd connection");
+            } else {  // Shepherd is already connected, but it's probably dead. This new connection is likely Shepherd trying to reconnect.
+                log_printf(DEBUG, "Restarting Shepherd connection");
+                stop_tcp_conn(SHEPHERD);
+            }
             start_tcp_conn(SHEPHERD, connfd, 0);
-        } else if (client_id == 1 && cli_addr.sin_family == AF_INET && robot_desc_read(DAWN) == DISCONNECTED) {
-            log_printf(DEBUG, "Starting Dawn connection");
+        } else if (client_id == 1 && cli_addr.sin_family == AF_INET) {
+            if (robot_desc_read(DAWN) == DISCONNECTED) {
+                log_printf(DEBUG, "Starting Dawn connection");
+            } else {  // Dawn is already connected, but it's probably dead. This new connection is likely Dawn trying to reconnect.
+                log_printf(DEBUG, "Restarting Dawn connection");
+                stop_tcp_conn(DAWN);
+            }
             start_tcp_conn(DAWN, connfd, 1);
         } else {
             log_printf(ERROR, "Client is neither Dawn nor Shepherd");

--- a/net_handler/tcp_conn.c
+++ b/net_handler/tcp_conn.c
@@ -449,6 +449,7 @@ void start_tcp_conn(robot_desc_field_t client, int conn_fd, int send_logs) {
         log_printf(ERROR, "start_tcp_conn: Failed to create main TCP thread for %d: %s", client, strerror(errno));
         return;
     }
+    log_printf(DEBUG, "Successfully initialized TCP connection with client %d\n", client);
     robot_desc_write(client, CONNECTED);
 }
 

--- a/net_handler/udp_conn.c
+++ b/net_handler/udp_conn.c
@@ -232,6 +232,8 @@ static void* update_inputs(void* args) {
                 } else {
                     input_write(input->buttons, input->axes, source);
                 }
+            } else if (input->source == SOURCE__KEYBOARD) {
+                log_printf(INFO, "Received keyboard disconnected on UDP from Dawn!!");
             }
         }
         user_inputs__free_unpacked(inputs, NULL);


### PR DESCRIPTION
- signal handler for executor commented out
- log level dependent on signal received
- new protocol implemented for net_handler:
- Essentially determine the client, with a timeout if client ID isn't sent during a set amount of time
- Kill the previous version of dawn or shepherd and form a new connection with what is likely a new instance of Dawn and Shepherd 