### PR TITLE
[EXECUTOR] Fix executor not printing import error message to net handler

### DIFF
--- a/executor/executor.c
+++ b/executor/executor.c
@@ -85,6 +85,11 @@ static void reset_params() {
             // TODO: if more params for more devices need to be reset, follow construction above ^
         }
     }
+
+    // 2021 Game Specific Resets
+    robot_desc_write(HYPOTHERMIA, INACTIVE);
+    robot_desc_write(POISON_IVY, INACTIVE);
+    robot_desc_write(DEHYDRATION, INACTIVE);
 }
 
 


### PR DESCRIPTION
- Had to put the student API import before the student code import so that the `stderr` gets redirected first so that import errors get correctly sent to the log FIFO