### PR TITLE
[SYSTEMD][BUILD] New set_time.service and Travis builds cli

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,6 +10,7 @@ RUN echo 'export PATH=$PATH:~/runtime' >> ~/.bashrc
 
 # Build Runtime processes
 RUN ./runtime build
+RUN cd tests && make cli && cd .. # runtime build does not build the cli's; we want to build this in case something fails here
 
 # By default, run Runtime when the Docker container starts
 CMD ./runtime run

--- a/systemd/set_time.service
+++ b/systemd/set_time.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Sets the time on this raspberry pi when on CalVisitor
+
+[Service]
+Type=oneshot
+User=root
+WorkingDirectory=/home/pi
+ExecStart=/home/pi/runtime/systemd/set_time.sh
+KillSignal=SIGINT
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/set_time.sh
+++ b/systemd/set_time.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+date -s "$(curl -s --head http://google.com | grep ^Date: | sed 's/Date: //g')"


### PR DESCRIPTION
`set_time.service` and `set_time.sh` together will set the time on Raspberry Pi's because if they're connected to CalVisitor or Motherbase connected to CalVisitor, the raspberry pi's will not be able to access the NTP servers to get the current system clock, causing confusing Github messages and the like (certificate expired, certificate inactivated, etc.).

Travis used to not build the cli, which caused us to miss the dual `get_next_dev_data()` in `net_handler_cli` for months. Travis now builds the `cli` to make sure the they build properly in order to merge.

Closes #220 