### PR TITLE
[LOWCAR][DEV_HANDLER] Remove LED test in KoalaBear

### DIFF
--- a/dev_handler/Makefile
+++ b/dev_handler/Makefile
@@ -1,6 +1,6 @@
 LIBFLAGS=-pthread -lrt -Wall
 
-dev_handler: dev_handler.c message.c ../logger/logger.c ../runtime_util/runtime_util.c ../shm_wrapper/shm_wrapper.c
+dev_handler: dev_handler.c message.c message.h ../logger/logger.c ../runtime_util/runtime_util.c ../shm_wrapper/shm_wrapper.c
 	gcc $^ -o dev_handler $(LIBFLAGS)
 
 clean:

--- a/dev_handler/message.h
+++ b/dev_handler/message.h
@@ -15,10 +15,9 @@
 
 /* The maximum number of milliseconds to wait between each DEVICE_PING from a device
  * Waiting for this long will exit all threads for that device (doing cleanup as necessary)
- * TODO: Reduce this from 2000 to 1000; This is a temporary solution to fix KoalaBear timing out
- * See Issue #236
+ * It's reasonable to match the TIMEOUT that the Arduino uses.
  */
-#define TIMEOUT 2000
+#define TIMEOUT 1000
 
 // The number of milliseconds between each DEVICE_PING sent to the device
 #define PING_FREQ 250

--- a/lowcar/devices/Device/Device.cpp
+++ b/lowcar/devices/Device/Device.cpp
@@ -31,7 +31,7 @@ void Device::loop() {
                 // If this is the first DEVICE_PING received, send an ACKNOWLEDGEMENT
                 if (!this->enabled) {
                     this->msngr->send_message(MessageID::ACKNOWLEDGEMENT, &(this->curr_msg), &(this->dev_id));
-                    this->msngr->lowcar_printf("Device type %d with UID ending in %X contacted; sent ACK", (uint8_t) this->dev_id.type, this->dev_id.uid);
+                    this->msngr->lowcar_printf("Device type %d, UID 0x...%X sent ACK", (uint8_t) this->dev_id.type, this->dev_id.uid);
                     this->enabled = TRUE;
                     device_enable();
                 }
@@ -51,7 +51,7 @@ void Device::loop() {
     }
 
     // If it's been too long since we received a DEVICE_PING, disable the device
-    if ((this->timeout > 0) && (this->curr_time - this->last_received_ping_time >= this->timeout)) {
+    if (this->enabled && (this->timeout > 0) && (this->curr_time - this->last_received_ping_time >= this->timeout)) {
         device_reset();
         this->enabled = FALSE;
     }

--- a/lowcar/devices/Device/Device.h
+++ b/lowcar/devices/Device/Device.h
@@ -20,8 +20,9 @@ class Device {
      * Arguments:
      *    dev_type: The type of device (ex: LimitSwitch)
      *    dev_year: The device year
-     *    timeout: the maximum number of milliseconds to wait for a PING from
+     *    timeout: the maximum number of milliseconds to wait between PING messages from
      *      dev handler before disabling
+     *      It's reasonable to match the TIMEOUT that dev handler uses.
      */
     Device(DeviceType dev_type, uint8_t dev_year, uint32_t timeout = 1000);
 

--- a/lowcar/devices/KoalaBear/KoalaBear.cpp
+++ b/lowcar/devices/KoalaBear/KoalaBear.cpp
@@ -273,7 +273,6 @@ void KoalaBear::device_enable() {
     this->pid_enabled_b = TRUE;
 
     this->led->setup_LEDs();
-    this->led->test_LEDs();
 
     pinMode(AIN1, OUTPUT);
     pinMode(AIN2, OUTPUT);


### PR DESCRIPTION
- Function call adds a sleep(1) that causes timeout issue
- Timeout reduced back to 1000ms, which was increased to 2000s as a short term solution

Issue #236 was originally thought to be the reason behind the timeout issue. This PR won't close that issue because the issue addresses the hacky solution of forcing a lowcar device to reset by pretending that dev handler dies.