### PR TITLE
[CLI] Auto attach SHM_UI iff shm exists on start

### DIFF
--- a/tests/cli/shm_ui.c
+++ b/tests/cli/shm_ui.c
@@ -24,9 +24,9 @@
  *    sudo apt-get install libncurses5-dev libncursesw5-dev
  */
 #include <curses.h>
+#include <stdbool.h>
 #include <string.h>
 #include <sys/wait.h>
-#include <stdbool.h>
 
 #include "../../logger/logger.h"
 #include "../../runtime_util/runtime_util.h"
@@ -541,7 +541,7 @@ int main(int argc, char** argv) {
         shm_already_exists = true;
     } else {
         start_shm();
-        sleep(1); // Allow shm to initialize
+        sleep(1);  // Allow shm to initialize
     }
 
     // Start UI


### PR DESCRIPTION
Removes need to specify "attach" arg
```
if shm exists when shm_ui is started
    shm_init()
else:
    create shm
    sleep(1)
    And destroy shm on exit
```

This is part of issue #239. Completing this for shm_ui early because it can save us some headaches from forgetting to specify "attach". 