### PR TITLE
[LOWCAR] updated time for recieving device writes as well

### DIFF
--- a/lowcar/devices/Device/Device.cpp
+++ b/lowcar/devices/Device/Device.cpp
@@ -39,6 +39,7 @@ void Device::loop() {
                 break;
 
             case MessageID::DEVICE_WRITE:
+                this->last_received_ping_time = this->curr_time;
                 device_write_params(&(this->curr_msg));
                 break;
 


### PR DESCRIPTION
RESOLVED #246
Added a line under Device Write case to update time every time we receive a device write ping.