### PR TITLE
[LOWCAR] make sure lowcar parameter is valid

### DIFF
--- a/lowcar/devices/LimitSwitch/LimitSwitch.cpp
+++ b/lowcar/devices/LimitSwitch/LimitSwitch.cpp
@@ -14,8 +14,14 @@ LimitSwitch::LimitSwitch() : Device(DeviceType::LIMIT_SWITCH, 0) {
 
 size_t LimitSwitch::device_read(uint8_t param, uint8_t* data_buf) {
     // put pin value into data_buf and return the state of the switch
-    data_buf[0] = (digitalRead(this->pins[param]) == LOW);
-    return sizeof(uint8_t);
+    if (param < NUM_SWITCHES && param >= 0) {
+        data_buf[0] = (digitalRead(this->pins[param]) == LOW);
+        return sizeof(uint8_t);
+    }
+    else {
+        return 0;
+    }
+    
 }
 
 void LimitSwitch::device_enable() {

--- a/lowcar/devices/LineFollower/LineFollower.cpp
+++ b/lowcar/devices/LineFollower/LineFollower.cpp
@@ -13,9 +13,14 @@ LineFollower::LineFollower() : Device(DeviceType::LINE_FOLLOWER, 1) {
 
 size_t LineFollower::device_read(uint8_t param, uint8_t* data_buf) {
     // use data_ptr_float to shove 10-bit sensor reading into the data_buf
-    float* data_ptr_float = (float*) data_buf;
-    *data_ptr_float = 1.0 - ((float) analogRead(this->pins[param])) / 1023.0;
-    return sizeof(float);
+    if (param < NUM_PINS && param >=0) {
+        float* data_ptr_float = (float*) data_buf;
+        *data_ptr_float = 1.0 - ((float) analogRead(this->pins[param])) / 1023.0;
+        return sizeof(float);
+    } else {
+        return 0;
+    }
+
 }
 
 void LineFollower::device_enable() {

--- a/lowcar/devices/ServoControl/ServoControl.cpp
+++ b/lowcar/devices/ServoControl/ServoControl.cpp
@@ -20,20 +20,32 @@ ServoControl::ServoControl() : Device(DeviceType::SERVO_CONTROL, 1) {
 }
 
 size_t ServoControl::device_read(uint8_t param, uint8_t* data_buf) {
-    float* float_buf = (float*) data_buf;
-    float_buf[0] = this->positions[param];
-    return sizeof(float);
-}
-
-size_t ServoControl::device_write(uint8_t param, uint8_t* data_buf) {
-    float value = ((float*) data_buf)[0];
-    if (value < -1 || value > 1) {
+    if (param < NUM_SERVOS && param >= 0) {
+        float* float_buf = (float*) data_buf;
+        float_buf[0] = this->positions[param];
+        return sizeof(float);
+    } else {
         return 0;
     }
 
-    // if servo isn't attached yet, attach the pin to the servo object
-    if (!servos[param].attached()) {
-        servos[param].attach(this->pins[param]);
+}
+
+size_t ServoControl::device_write(uint8_t param, uint8_t* data_buf) {
+    if (param < NUM_SERVOS && param >= 0) {
+        float value = ((float*) data_buf)[0];
+        if (value < -1 || value > 1) {
+            return 0;
+        }
+
+        // if servo isn't attached yet, attach the pin to the servo object
+        if (!servos[param].attached()) {
+            servos[param].attach(this->pins[param]);
+        }
+        this->positions[param] = value;
+        servos[param].writeMicroseconds(ServoControl::SERVO_CENTER + (this->positions[param] * ServoControl::SERVO_RANGE / 2.0));
+        return sizeof(float);
+    } else {
+        return 0;
     }
     this->positions[param] = value;
     servos[param].writeMicroseconds(ServoControl::SERVO_CENTER + (this->positions[param] * ServoControl::SERVO_RANGE));


### PR DESCRIPTION
RESOLVED #253 
We should make sure that device_read()/device_write() for all the devices return 0 if the param argument is invalid.

In LimitSwitch::device_read(), we call digitalRead() with the argument param, even if might not refer to a relevant pin.