### PR TITLE
[BUILD] Removed cron trigger for workflow

### DIFF
--- a/.github/workflows/pull_request_ci.yml
+++ b/.github/workflows/pull_request_ci.yml
@@ -7,15 +7,12 @@ name: CI
 # Under what conditions do we run this workflow? Either
 # a) It is a commit on a pull request on a branch to be merged into master
 # b) It is a push to master (which only happens when we close a pull request)
-# c) It's 10:45 UTC on the 1st, 8th, 15th, 22nd, or 29th of a month (to prevent the cache from expiring)
 on:
   pull_request:
     branches: [master]
     types: [opened, synchronize]
   push:
     branches: [master]
-  schedule:
-    - cron: '45 10 1,8,15,22,29 * *'
 
 # Here is the list of jobs that this workflow will run. There is only one job.
 jobs:


### PR DESCRIPTION
The idea behind putting a schedule on the CI build was to make sure that the cache never expired. However, since it seems that a cache is only valid when run on the same PR/same branch, this doesn’t matter since we won’t be able to transfer the cache between PRs or between a working branch and master. I removed it in this PR.