### PR TITLE
[EXECUTOR] Updated Python version to 3.11

### DIFF
--- a/executor/Makefile
+++ b/executor/Makefile
@@ -5,7 +5,7 @@ LIBS=-pthread -lrt -Wall -export-dynamic -fPIC
 SRCS = executor.c gamestate_filter.c ../logger/logger.c ../runtime_util/runtime_util.c ../shm_wrapper/shm_wrapper.c
 
 # Python compilation definitions
-PY_VER = python3.10
+PY_VER = python3.11
 PY_LIB = -l$(PY_VER)
 CFLAGS = $(shell $(PY_VER)-config --cflags)
 

--- a/executor/executor.c
+++ b/executor/executor.c
@@ -1,7 +1,7 @@
 #define PY_SSIZE_T_CLEAN
 #include <arpa/inet.h>          //for networking
 #include <pthread.h>            //for POSIX threads
-#include <python3.10/Python.h>  // For Python's C API
+#include <python3.11/Python.h>  // For Python's C API
 #include <signal.h>             // Used to handle SIGTERM, SIGINT, SIGKILL
 #include <stdint.h>             //for standard int types
 #include <stdio.h>              //for i/o


### PR DESCRIPTION
I just updated the Python version in executor so we don't have to manually change it on the Raspberry Pi's like we had to do this past spring.